### PR TITLE
fix(tabs): fix selected styles

### DIFF
--- a/src/components/beta/gux-tabs/gux-tab/gux-tab.less
+++ b/src/components/beta/gux-tabs/gux-tab/gux-tab.less
@@ -1,5 +1,5 @@
 // Variables part
-@gux-off-tab-fill: #CFD1D1;
+@gux-off-tab-fill: #cfd1d1;
 
 // Style
 .popover-content {
@@ -36,7 +36,7 @@ gux-tab {
       font-size: 12px;
 
       &:after {
-        content: "";
+        content: '';
         display: block;
         position: absolute;
         width: 14px;
@@ -143,7 +143,7 @@ gux-tab {
 }
 
 .gux-light-theme {
-  gux-tabs {
+  gux-tabs-beta {
     .gux-tabs-light-theme();
   }
 }
@@ -154,20 +154,19 @@ gux-tabs.gux-light-theme {
 
 // Dark
 .gux-tabs-dark-theme {
-
 }
 
 .gux-dark-theme {
-  gux-tabs {
+  gux-tabs-beta {
     .gux-tabs-dark-theme();
   }
 }
 
-gux-tabs.gux-dark-theme {
+gux-tabs-beta.gux-dark-theme {
   .gux-tabs-dark-theme();
 }
 
 // Default
-gux-tabs {
+gux-tabs-beta {
   .gux-tabs-light-theme();
 }

--- a/src/i18n/locales.json
+++ b/src/i18n/locales.json
@@ -22,7 +22,6 @@
   "zh-cn",
   "zh-tw",
   "en",
-  "locales",
   "ar",
   "cs",
   "da",


### PR DESCRIPTION
The migration from gux-tabs to gux-tabs-beta inadvertently broke some styling in the tab component

COMUI-243