### PR TITLE
docs(changelog): improve changelog notes for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
-* component tag changes
+
+* The following tags have been renamed using our new beta naming scheme. Consumers using these tags will need to update their repos to use the new tag names:
+  * gux-command-palette -> gux-command-palette-beta
+  * gux-panel-frame -> gux-panel-frame-beta
+  * gux-rating -> gux-rating-beta
+  * gux-search -> gux-search-beta
+  * gux-side-panel -> gux-side-panel-beta
+  * gux-switch -> gux-switch-beta
+  * gux-tabs -> gux-tabs-beta
+  * gux-time-picker -> gux-time-picker-beta
+  * gux-tooltip -> gux-tooltip-beta
+
 * **localization:** language files may need to be uploaded to a new path
 * **gux-pagination:** api changes to both props and events
 


### PR DESCRIPTION
The changelog didn't have a good description of the recent beta tag renames so
I added them for the 1.0 release