### PR TITLE
ci(jenkinsfile): avoid build loops

### DIFF
--- a/src/components/beta/gux-tabs/gux-tabs.tsx
+++ b/src/components/beta/gux-tabs/gux-tabs.tsx
@@ -86,7 +86,9 @@ export class GuxTabs {
       this.destroySortable();
     }
 
-    this.resizeObserver?.unobserve(this.element.querySelector('.gux-tabs'));
+    if (this.resizeObserver) {
+      this.resizeObserver.unobserve(this.element.querySelector('.gux-tabs'));
+    }
   }
 
   async componentWillLoad(): Promise<void> {
@@ -107,7 +109,9 @@ export class GuxTabs {
       });
     }
 
-    this.resizeObserver?.observe(this.element.querySelector('.gux-tabs'));
+    if (this.resizeObserver) {
+      this.resizeObserver.observe(this.element.querySelector('.gux-tabs'));
+    }
 
     const tabElements = this.element.querySelectorAll('gux-tab');
     tabElements.forEach(tab => {


### PR DESCRIPTION
Avoid build loops by checking to see if the last commit was a release commit when building

I was able to validate that this does avoid build loops by using Jenkins' replay feature, but I'll also want to check that it builds correctly after we've merged some PRs for builds that shouldn't be skipped.