### PR TITLE
fix(gux-table): resizeObserver not present in spec tests

### DIFF
--- a/src/components/beta/gux-table/gux-table.tsx
+++ b/src/components/beta/gux-table/gux-table.tsx
@@ -238,16 +238,20 @@ export class GuxTable {
         });
       }
 
-      this.resizeObserver.observe(
-        this.tableContainer.querySelector('.gux-table-container table')
-      );
+      if (this.resizeObserver) {
+        this.resizeObserver.observe(
+          this.tableContainer.querySelector('.gux-table-container table')
+        );
+      }
     });
   }
 
   disconnectedCallback(): void {
-    this.resizeObserver.unobserve(
-      this.tableContainer.querySelector('.gux-table-container table')
-    );
+    if (this.resizeObserver) {
+      this.resizeObserver.unobserve(
+        this.tableContainer.querySelector('.gux-table-container table')
+      );
+    }
   }
 
   render() {


### PR DESCRIPTION
added guards to resizeObserver calls if it is undefined