### PR TITLE
fix(doc-site): fix the sort order of components

### DIFF
--- a/docs/src/component-listing/app.js
+++ b/docs/src/component-listing/app.js
@@ -7,7 +7,7 @@ export function bootstrap() {
   let components = Object.keys(COMPONENT_SPEC)
     .filter(component => !COMPONENT_SPEC[component].hidePage)
     .sort((a, b) => {
-      return a < b ? -1 : 1;
+      return shortName(a) < shortName(b) ? -1 : 1;
     });
 
   document.body.appendChild(


### PR DESCRIPTION
I noticed this when looking at the color PR, so here's a quick fix.