### PR TITLE
ci(jenkins): fix uploading of feature branches

### DIFF
--- a/scripts/version-helper.js
+++ b/scripts/version-helper.js
@@ -1,12 +1,5 @@
-const prereleaseRegex = /-(alpha|beta)\.\d+$/;
-
 function getDeployVersion() {
-  const packageVersion = require('../package.json').version;
-  if (prereleaseRegex.test(packageVersion)) {
-    return packageVersion.replace(prereleaseRegex, '-$1');
-  } else {
-    return packageVersion;
-  }
+  return require('../package.json').version;
 }
 
 module.exports = {


### PR DESCRIPTION
Feature branch uploads were almost working, but the Jenkinsfile was missing logic to handle
overriding the upload version. This adds that and cleans up a bit of old code related to alpha
deploys that I found while working.

any existing `feature/...` branches will need to be rebased/merged with this to get their deploys working. 