### PR TITLE
docs(attribute-panel): hide attribute panel with gux-disclosure-button

### DIFF
--- a/docs/src/component-viewer/app.js
+++ b/docs/src/component-viewer/app.js
@@ -24,16 +24,18 @@ function createLayout() {
         <div class="preview gux-light-theme"></div>
         <div class="editor"></div>
       </div>
-      <div class="right-column">
-        <details>
-          <summary class="heading">Attributes</summary>
-          <div class="attributes"></div>
-        </details>
-        <details>
-          <summary class="heading">Event Details</summary>
-          <div class="events"></div>
-        </details>
-      </div>
+      <gux-disclosure-button position="right">
+        <div slot="panel-content" class="controls-column">
+          <details>
+            <summary class="heading">Event Descriptions</summary>
+            <div class="events"></div>
+          </details>
+          <details>
+            <summary class="heading">Attributes</summary>
+            <div class="attributes"></div>
+          </details>
+        </div>
+      </gux-disclosure-button>
       <div class="notification"></div>
     </div>
   `);

--- a/docs/src/styles/component-viewer.less
+++ b/docs/src/styles/component-viewer.less
@@ -69,7 +69,7 @@ body {
   }
 }
 
-.component-viewer > .right-column {
+.component-viewer .controls-column {
   width: 300px;
   overflow: auto;
   line-height: 1.4em;
@@ -113,7 +113,6 @@ body {
           font-weight: 800;
         }
       }
-
     }
   }
 


### PR DESCRIPTION
This hides the attribute/event panel in the demo docs with a gux-disclosure-button. It's not the
most discoverable approach, but it's a good quick fix to make the embedded docs look a lot less
cluttered, IMO.

COMUI-270