### PR TITLE
fix(gux-tab): fix margin of gux-tab dropdown

### DIFF
--- a/src/components/beta/gux-tabs/gux-tab/gux-tab.less
+++ b/src/components/beta/gux-tabs/gux-tab/gux-tab.less
@@ -3,11 +3,15 @@
 @gux-off-tab-fill: #cfd1d1;
 
 // Style
-.popover-content {
-  margin: 5px 0 !important;
-}
-
 gux-tab {
+  gux-popover {
+    z-index: 1000;
+
+    .gux-popover-wrapper .gux-popover-content {
+      margin: 5px 0;
+    }
+  }
+
   .gux-tab {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Before
<img width="307" alt="Screen Shot 2020-11-04 at 5 09 03 PM" src="https://user-images.githubusercontent.com/17623706/98173131-8d69b000-1ec0-11eb-9077-ee9703b38fcf.png">


## After
<img width="286" alt="Screen Shot 2020-11-04 at 5 09 12 PM" src="https://user-images.githubusercontent.com/17623706/98173145-92c6fa80-1ec0-11eb-8639-5a754114205e.png">
