### PR TITLE
fix(icons): improve handling for non-square icon svgs

### DIFF
--- a/src/components/stable/gux-icon/example.html
+++ b/src/components/stable/gux-icon/example.html
@@ -5,7 +5,7 @@
 </p>
 
 <h1>Accessibility</h1>
-<gux-icon class="example" icon-name="add-user" decorative="true"></gux-icon>
+<gux-icon class="example" icon-name="cc-delivery" decorative="true"></gux-icon>
 <p>
   Set the <strong>decorative</strong> attrribute if the icon does not convey
   information about the page and is only for decoration
@@ -21,7 +21,7 @@
   information to the user that would not otherwise be available
 </p>
 
-<gux-icon class="example" icon-name="add-user"></gux-icon>
+<gux-icon class="example" icon-name="cc-disconnected-system"></gux-icon>
 <p>
   If neither <strong>decorative</strong> or <strong>screenreader-text</strong>
   are set an error will be logged in the console

--- a/src/components/stable/gux-icon/gux-icon.less
+++ b/src/components/stable/gux-icon/gux-icon.less
@@ -8,11 +8,16 @@ gux-icon {
 
   .gux-icon-container {
     width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     svg {
       fill: currentColor;
-      height: unset;
+      height: 100%;
       width: 100%;
+      max-height: 100%;
+      max-width: 100%;
     }
   }
 }


### PR DESCRIPTION
in some cases, icons svgs without a square aspect ratio would overflow the gux-icon component or not
be centered within it. This corrects those issues.

COMUI-333