### PR TITLE
fix(pagination): drop-up instead of drop-down

### DIFF
--- a/src/components/stable/gux-pagination/gux-pagination-items-per-page/gux-pagination-items-per-page.less
+++ b/src/components/stable/gux-pagination/gux-pagination-items-per-page/gux-pagination-items-per-page.less
@@ -18,5 +18,13 @@ gux-pagination-items-per-page {
       width: 60px;
       margin: 0 8px 0 16px;
     }
+
+    gux-dropdown {
+      div.gux-dropdown .gux-options.gux-opened {
+        bottom: 100%;
+        display: flex;
+        flex-direction: column-reverse;
+      }
+    }
   }
 }


### PR DESCRIPTION
The pagination component is almost always placed at the bottom of the page, but the item count
selection uses a dropdown, which is awkward in that position. This is a bit of a kludgy fix to make
the component drop-up instead, until we land COMUI-242, which should give us a better general
mechanism for this behavior.