### PR TITLE
fix(gux-dropdown): revert to no value if invalid value entered when focus is lost

### DIFF
--- a/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -72,6 +72,13 @@ export class GuxDropdown {
     if (!e.relatedTarget || !this.root.contains(e.relatedTarget as Node)) {
       this.opened = false;
       this.forcedGhostValue = '';
+      const selectionOptions = this.getSelectionOptions();
+      const match = selectionOptions.some(item => {
+        return item.text === this.value;
+      });
+      if (!match) {
+        this.setValue('', '');
+      }
     }
   }
 


### PR DESCRIPTION
Fix dropdown behavior, to show placeholder if focus is lost while an invalid value was entered.

fix https://inindca.atlassian.net/browse/COMUI-339