### PR TITLE
fix(gux-disclosure-button): update icon when is-open attribute changes

### DIFF
--- a/src/components/stable/gux-disclosure-button/gux-disclosure-button.tsx
+++ b/src/components/stable/gux-disclosure-button/gux-disclosure-button.tsx
@@ -1,4 +1,12 @@
-import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
+import {
+  Component,
+  Event,
+  EventEmitter,
+  h,
+  Prop,
+  State,
+  Watch
+} from '@stencil/core';
 
 import { GuxDisclosureButtonPosition } from './gux-disclosure-button.types';
 
@@ -37,6 +45,12 @@ export class GuxDisclosureButton {
    */
   @Event()
   active: EventEmitter;
+
+  @Watch('isOpen')
+  watchIsOpen() {
+    this.updateIcon();
+  }
+
   changeState() {
     this.togglePanel();
     this.active.emit(this.isOpen);
@@ -44,7 +58,6 @@ export class GuxDisclosureButton {
 
   togglePanel() {
     this.isOpen = !this.isOpen;
-    this.updateIcon();
   }
 
   updateIcon() {

--- a/src/components/stable/gux-disclosure-button/tests/gux-disclosure-button.e2e.ts
+++ b/src/components/stable/gux-disclosure-button/tests/gux-disclosure-button.e2e.ts
@@ -41,4 +41,57 @@ describe('gux-disclosure-button', () => {
       expect(panel).toHaveClass('gux-active');
     });
   });
+
+  describe('button icon', () => {
+    const expandRight = 'ic-expand-right';
+    const expandLeft = 'ic-expand-left';
+
+    const testStates = [
+      {
+        initial: { position: 'left', isOpen: false, expectedIcon: expandRight },
+        updated: { isOpen: true, expectedIcon: expandLeft }
+      } as const,
+      {
+        initial: { position: 'right', isOpen: false, expectedIcon: expandLeft },
+        updated: { isOpen: true, expectedIcon: expandRight }
+      } as const
+    ];
+
+    testStates.forEach(({ initial, updated }, index) => {
+      it(`should update on is-open change (${index + 1})`, async () => {
+        const page = await newE2EPage();
+
+        await page.setContent(
+          `<gux-disclosure-button position="${initial.position}" is-open="${initial.isOpen}"></gux-disclosure-button>`
+        );
+        page.waitForChanges();
+
+        const disclosureElement = await page.find('gux-disclosure-button');
+        const iconElement = await page.find('gux-icon');
+
+        expect(iconElement).toEqualAttribute('icon-name', initial.expectedIcon);
+
+        disclosureElement.setAttribute('is-open', updated.isOpen);
+        await page.waitForChanges();
+        expect(iconElement).toEqualAttribute('icon-name', updated.expectedIcon);
+      });
+
+      it(`should update on button click (${index + 1})`, async () => {
+        const page = await newE2EPage();
+
+        await page.setContent(
+          `<gux-disclosure-button position="${initial.position}" is-open="${initial.isOpen}"></gux-disclosure-button>`
+        );
+        page.waitForChanges();
+
+        const buttonElement = await page.find('.gux-disclosure-button');
+        const iconElement = await page.find('gux-icon');
+
+        expect(iconElement).toEqualAttribute('icon-name', initial.expectedIcon);
+
+        await buttonElement.click();
+        expect(iconElement).toEqualAttribute('icon-name', updated.expectedIcon);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Update icon when is-open attribute changes

The updateIcon() function was called when the button was clicked, but not when `is-open` attribute was updated

COMUI-336