### PR TITLE
fix(i18n): fix i18n build in Jenkins

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "dist/"
   ],
   "scripts": {
-    "build": "npm run i18n && npm run stencil && npm run docs && npm run build-wrapper",
+    "build": "npm run clean && npm run i18n && npm run stencil && npm run docs && npm run build-wrapper",
     "build-wrapper": "./scripts/wrap-stencil.js",
     "check-readmes": "./scripts/check-readmes.sh",
+    "clean": "rm -r ./dist",
     "commit": "git-cz",
     "create-component": "node scripts/create-component.js",
     "dev": "./node_modules/.bin/concurrently  \"npm run stencil.dev\" \"npm run docs.dev\"",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -37,7 +37,8 @@ export const config: Config = {
             ],
             dest: 'dist/genesys-webcomponents/less'
           }
-        ]
+        ],
+        verbose: true
       }),
       {
         name: 'generate-metadata',


### PR DESCRIPTION
When building in Jenkins, i18n files were not being correctly added to the 'dist' folder. This fixes
that issue.

COMUI-341


This one was a bear to sort out. There's no obvious reason it wouldn't work, but I eventually realized that if I ran multiple builds locally, every other build would be missing the files from the rollup copy plugin. Since the Jenkins job builds the components for running tests and for deployment, that seemed like a likely culprit, so I tried removing the output directory before building, and that solved the problem.