### PR TITLE
docs(gux-icon): added a list of all icons to the docs page

### DIFF
--- a/docs/src/utils/generateIconsPage.js
+++ b/docs/src/utils/generateIconsPage.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+
+/* Dynamically generates a list of all icons present in the Gux Icons Iconset **/
+function generateHTML(path) {
+  const files = fs.readdirSync(path);
+  let output = `<div class="icons-container">`;
+
+  for (let icon of files) {
+    if (!icon.endsWith('.svg')) continue;
+
+    const iconName = icon.substring(0, icon.length - 4); // remove .svg suffix
+
+    output += `<div class="icon-example">
+  <gux-icon icon-name="${iconName}" class="example" decorative="true"></gux-icon>
+  <div class="icon-name">${iconName}</div>
+</div>
+`;
+  }
+
+  output += '</div>';
+  return output;
+}
+
+exports.generateHTML = generateHTML;

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -92,7 +92,17 @@ const componentPageTemplate = fs
 function generateComponentPage(exampleMarkup) {
   const withCdn = injectCdnUrl(componentPageTemplate);
   const sanitizedMarkup = exampleMarkup.toString().replace(/`/g, '\\`');
-  return withCdn.replace('${EXAMPLE_HTML}', sanitizedMarkup);
+  let withHtml = withCdn.replace('${EXAMPLE_HTML}', sanitizedMarkup);
+
+  if (withHtml.includes('${ICON_EXAMPLE_LIST}')) {
+    const iconScript = require('./src/utils/generateIconsPage');
+    const iconsExamplesHtml = iconScript.generateHTML(
+      '../src/components/stable/gux-icon/icons'
+    );
+    withHtml = withHtml.replace('${ICON_EXAMPLE_LIST}', iconsExamplesHtml);
+  }
+
+  return withHtml;
 }
 
 function injectCdnUrl(content) {

--- a/src/components/stable/gux-icon/example.html
+++ b/src/components/stable/gux-icon/example.html
@@ -104,7 +104,9 @@
     decorative="true"
   ></gux-icon>
 </div>
-<p>Duplicated icons should not require additional newtwork calls</p>
+<p>Duplicated icons should not require additional network calls</p>
+
+${ICON_EXAMPLE_LIST}
 
 <style
   onload="(function () {
@@ -116,7 +118,6 @@
   guxIcon.setAttribute('icon-name', 'add-user');
   guxIcon.setAttribute('screenreader-text', 'test');
   guxIcon.setAttribute('style', 'width: 50px; height: 50px;');
-
   shadowRoot.appendChild(guxIcon);
 })()"
 >

--- a/src/components/stable/gux-icon/gux-icon.less
+++ b/src/components/stable/gux-icon/gux-icon.less
@@ -21,3 +21,18 @@ gux-icon {
     }
   }
 }
+
+.icons-container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+
+  .icon-example {
+    width: 100px;
+    height: 100px;
+    text-align: center;
+    padding-top: 20px;
+    margin-left: 5px;
+    margin-bottom: 5px;
+  }
+}


### PR DESCRIPTION
Dynamically generate a list of all `.svg` files in the `/src/components/stable/gux-icon/icons` and places them inside HTML elements on the `gux-icon` docs page during the webpack build.