### PR TITLE
fix(gux-tabs): re-check scrollbar hide/show when dom changes

### DIFF
--- a/src/components/beta/gux-tabs/gux-tabs.tsx
+++ b/src/components/beta/gux-tabs/gux-tabs.tsx
@@ -123,7 +123,7 @@ export class GuxTabs {
     }
 
     if (this.domObserver) {
-      this.domObserver.unobserve(this.element);
+      this.domObserver.disconnect();
     }
   }
 
@@ -133,7 +133,7 @@ export class GuxTabs {
 
   checkForScrollbarHideOrShow() {
     readTask(() => {
-      const el = this.element.shadowRoot.querySelector('.scrollable-section');
+      const el = this.root.shadowRoot.querySelector('.scrollable-section');
       const hasScrollbar = el.clientWidth !== el.scrollWidth;
 
       if (hasScrollbar !== this.hasScrollbar) {
@@ -166,7 +166,7 @@ export class GuxTabs {
     }
 
     if (this.domObserver) {
-      this.domObserver.observe(this.element, {
+      this.domObserver.observe(this.root, {
         childList: true,
         attributes: false,
         subtree: true

--- a/src/components/beta/gux-tabs/gux-tabs.tsx
+++ b/src/components/beta/gux-tabs/gux-tabs.tsx
@@ -63,6 +63,8 @@ export class GuxTabs {
 
   private resizeObserver?: ResizeObserver;
 
+  private domObserver?: MutationObserver;
+
   @Watch('value')
   watchHandler(newValue: string) {
     const tabs: HTMLGuxTabElement[] = Array.from(
@@ -119,10 +121,25 @@ export class GuxTabs {
         this.root.shadowRoot.querySelector('.gux-tabs')
       );
     }
+
+    if (this.domObserver) {
+      this.domObserver.unobserve(this.element);
+    }
   }
 
   async componentWillLoad(): Promise<void> {
     this.i18n = await buildI18nForComponent(this.root, tabsResources);
+  }
+
+  checkForScrollbarHideOrShow() {
+    readTask(() => {
+      const el = this.element.shadowRoot.querySelector('.scrollable-section');
+      const hasScrollbar = el.clientWidth !== el.scrollWidth;
+
+      if (hasScrollbar !== this.hasScrollbar) {
+        this.hasScrollbar = hasScrollbar;
+      }
+    });
   }
 
   componentDidLoad() {
@@ -131,12 +148,9 @@ export class GuxTabs {
     }
 
     if (!this.resizeObserver && window.ResizeObserver) {
-      this.resizeObserver = new ResizeObserver(() => {
-        readTask(() => {
-          const el = this.root.shadowRoot.querySelector('.scrollable-section');
-          this.hasScrollbar = el.clientWidth !== el.scrollWidth;
-        });
-      });
+      this.resizeObserver = new ResizeObserver(
+        this.checkForScrollbarHideOrShow.bind(this)
+      );
     }
 
     if (this.resizeObserver) {
@@ -144,16 +158,26 @@ export class GuxTabs {
         this.root.shadowRoot.querySelector('.gux-tabs')
       );
     }
+
+    if (!this.domObserver && window.MutationObserver) {
+      this.domObserver = new MutationObserver(
+        this.checkForScrollbarHideOrShow.bind(this)
+      );
+    }
+
+    if (this.domObserver) {
+      this.domObserver.observe(this.element, {
+        childList: true,
+        attributes: false,
+        subtree: true
+      });
+    }
   }
 
   componentDidRender() {
     setTimeout(() => {
       readTask(() => {
-        const el = this.root.shadowRoot.querySelector('.scrollable-section');
-        const hasScrollbar = el.clientWidth !== el.scrollWidth;
-        if (this.hasScrollbar !== hasScrollbar) {
-          this.hasScrollbar = hasScrollbar;
-        }
+        this.checkForScrollbarHideOrShow();
 
         if (this.value) {
           const activeTab: any = this.root.querySelector(


### PR DESCRIPTION
Issue: the scrollbar on gux-tabs would continue to show when tabs were removed

Example Before This Fix:
![before](https://user-images.githubusercontent.com/17623706/105758451-47e7dc80-5f1d-11eb-8507-596035ede53d.gif)

Example After This Fix:
![after](https://user-images.githubusercontent.com/17623706/105758472-4dddbd80-5f1d-11eb-94d8-3c8d43db8904.gif)

MutationObserver is supported on all major browsers (including IE11)
<img width="1007" alt="Screen Shot 2021-01-25 at 2 55 45 PM" src="https://user-images.githubusercontent.com/17623706/105758628-74035d80-5f1d-11eb-81ad-c81f0eb8e78a.png">