### PR TITLE
fix(gux-row-select): update gux-row-select to use gux-checkbox-legacy

### DIFF
--- a/src/components/beta/gux-table/gux-row-select/gux-row-select.tsx
+++ b/src/components/beta/gux-table/gux-row-select/gux-row-select.tsx
@@ -27,6 +27,6 @@ export class GuxRowSelect {
   }
 
   render(): JSX.Element {
-    return <gux-checkbox checked={this.selected}></gux-checkbox>;
+    return <gux-checkbox-legacy checked={this.selected}></gux-checkbox-legacy>;
   }
 }


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-435

The component was using gux-checkbox but with the move to 2.0 it needed to get -legacy added to it so it would still work.