### PR TITLE
fix(gux-tag color type): fixed a typo in the tag color type

### DIFF
--- a/src/components/beta/gux-tag/gux-tag.types.ts
+++ b/src/components/beta/gux-tag/gux-tag.types.ts
@@ -9,4 +9,4 @@ export type GuxTagColor =
   | 'bubblegum-pink'
   | 'olive-green'
   | 'lilac'
-  | 'alert-ellow-green';
+  | 'alert-yellow-green';

--- a/src/components/beta/gux-tag/readme.md
+++ b/src/components/beta/gux-tag/readme.md
@@ -7,13 +7,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 ## Properties
 
-| Property    | Attribute   | Description           | Type                                                                                                                                                                     | Default     |
-| ----------- | ----------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| `color`     | `color`     | Tag background color. | `"alert-ellow-green" \| "aqua-green" \| "blue" \| "bubblegum-pink" \| "dark-purple" \| "default" \| "electric-purple" \| "fuscha" \| "lilac" \| "navy" \| "olive-green"` | `'default'` |
-| `disabled`  | `disabled`  | Tag is removable.     | `boolean`                                                                                                                                                                | `false`     |
-| `icon`      | `icon`      | Tag icon name.        | `string`                                                                                                                                                                 | `undefined` |
-| `removable` | `removable` | Tag is removable.     | `boolean`                                                                                                                                                                | `false`     |
-| `value`     | `value`     | Index for remove tag  | `string`                                                                                                                                                                 | `undefined` |
+| Property    | Attribute   | Description           | Type                                                                                                                                                                      | Default     |
+| ----------- | ----------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `color`     | `color`     | Tag background color. | `"alert-yellow-green" \| "aqua-green" \| "blue" \| "bubblegum-pink" \| "dark-purple" \| "default" \| "electric-purple" \| "fuscha" \| "lilac" \| "navy" \| "olive-green"` | `'default'` |
+| `disabled`  | `disabled`  | Tag is removable.     | `boolean`                                                                                                                                                                 | `false`     |
+| `icon`      | `icon`      | Tag icon name.        | `string`                                                                                                                                                                  | `undefined` |
+| `removable` | `removable` | Tag is removable.     | `boolean`                                                                                                                                                                 | `false`     |
+| `value`     | `value`     | Index for remove tag  | `string`                                                                                                                                                                  | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
Fixed a typo in the `GuxTagColor` type

`alert-ellow-green` is updated to `alert-yellow-green`