### PR TITLE
build(docs-build): webpack config is updated to use development mode …

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,8 @@
   "author": "Eric Lifka <eric.lifka@genesys.com>",
   "license": "MIT",
   "scripts": {
-    "start": "webpack serve",
-    "build": "webpack"
+    "start": "webpack serve --mode=development",
+    "build": "webpack --mode=production"
   },
   "staticFiles": {
     "staticPath": "../dist/genesys-webcomponents",


### PR DESCRIPTION
`npm run dev` is taking lot of time to start as well as re-compiling takes too long.

specifying the `mode` for `webpack serve` will fix this issue.