### PR TITLE
fix(gux-advanced-dropdown): text overflow issues are fixed

### DIFF
--- a/src/components/stable/gux-advanced-dropdown/dropdown-option/gux-dropdown-option.less
+++ b/src/components/stable/gux-advanced-dropdown/dropdown-option/gux-dropdown-option.less
@@ -10,8 +10,11 @@ gux-dropdown-option {
   line-height: 32px;
   cursor: pointer;
 
-  div {
+  div.gux-dropdown-option {
     position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
     .gux-ghost {
       position: absolute;

--- a/src/components/stable/gux-advanced-dropdown/dropdown-option/gux-dropdown-option.tsx
+++ b/src/components/stable/gux-advanced-dropdown/dropdown-option/gux-dropdown-option.tsx
@@ -122,7 +122,11 @@ export class GuxDropdownOption {
   }
 
   render() {
-    return <div>{this.textWithHighlights()}</div>;
+    return (
+      <div class="gux-dropdown-option" title={this.text}>
+        {this.textWithHighlights()}
+      </div>
+    );
   }
 
   private textWithHighlights() {

--- a/src/components/stable/gux-advanced-dropdown/example.html
+++ b/src/components/stable/gux-advanced-dropdown/example.html
@@ -1,10 +1,38 @@
+<div style="width: 150px">
+  <gux-advanced-dropdown placeholder="[None]" filter-debounce-timeout="250">
+    <gux-dropdown-option
+      value="en-US"
+      text="American English"
+    ></gux-dropdown-option>
+    <gux-dropdown-option
+      selected
+      value="es"
+      text="Latin American Spanish"
+    ></gux-dropdown-option>
+    <gux-dropdown-option
+      value="es-ES"
+      text="European Spanish"
+    ></gux-dropdown-option>
+    <gux-dropdown-option value="en-UK" text="UK English"></gux-dropdown-option>
+    <gux-dropdown-option
+      value="fr-CA"
+      text="Canadian French"
+    ></gux-dropdown-option>
+    <gux-dropdown-option
+      value="fr"
+      text="European French"
+    ></gux-dropdown-option>
+    <gux-dropdown-option value="nl" text="Dutch"></gux-dropdown-option>
+  </gux-advanced-dropdown>
+</div>
+
 <gux-advanced-dropdown placeholder="[None]" filter-debounce-timeout="250">
   <gux-dropdown-option
-    selected
     value="en-US"
     text="American English"
   ></gux-dropdown-option>
   <gux-dropdown-option
+    selected
     value="es"
     text="Latin American Spanish"
   ></gux-dropdown-option>

--- a/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
+++ b/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
@@ -42,7 +42,10 @@ div.gux-dropdown {
       right: 0;
       bottom: 0;
       left: 0;
-      padding: 5px 12px 4px 12px;
+      padding: 5px 24px 4px 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
       cursor: pointer;
       border: 1px solid @border-color;
       border-radius: 2px;

--- a/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.tsx
+++ b/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.tsx
@@ -155,9 +155,15 @@ export class GuxAdvancedDropdown {
             onKeyDown={e => this.inputKeyDown(e)}
           >
             {this.placeholder && !this.value && (
-              <span class="gux-select-placeholder">{this.placeholder}</span>
+              <span class="gux-select-placeholder" title={this.placeholder}>
+                {this.placeholder}
+              </span>
             )}
-            {this.value && <span class="gux-select-value">{this.value}</span>}
+            {this.value && (
+              <span class="gux-select-value" title={this.value}>
+                {this.value}
+              </span>
+            )}
           </a>
           <div class="gux-icon-wrapper">
             <gux-icon decorative icon-name="chevron-small-down"></gux-icon>


### PR DESCRIPTION
Text overflows and overlapping issues are now fixed.
After Fix:
![image](https://user-images.githubusercontent.com/5516663/122176944-c3cdcb80-cea2-11eb-890f-dddc9d43e832.png)

Before Fix:
![image](https://user-images.githubusercontent.com/5516663/122177350-2921bc80-cea3-11eb-951f-cc63dbc009ea.png)

![image](https://user-images.githubusercontent.com/5516663/122177389-3179f780-cea3-11eb-9def-c375f44aec24.png)


Also did a testing with screenreader to check if it is reading only once, and it passed. 
Since the `title` attribute is added to elements which is not having `tabIndex=0` or focusable, the screenreader is working just fine.