### PR TITLE
fix(gux-input-range): fixed bug with gux-input-range race condition

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-input-range/gux-input-range.tsx
+++ b/src/components/stable/gux-form-field/components/gux-input-range/gux-input-range.tsx
@@ -88,7 +88,7 @@ export class GuxInputRange {
     return this.value;
   }
 
-  connectedCallback(): void {
+  componentWillLoad(): void {
     this.input = this.root.querySelector('input[slot="input"]');
     this.disabled = this.input.disabled;
     this.value = this.input.value;

--- a/src/components/stable/gux-form-field/components/gux-input-range/gux-input-range.tsx
+++ b/src/components/stable/gux-form-field/components/gux-input-range/gux-input-range.tsx
@@ -88,6 +88,8 @@ export class GuxInputRange {
     return this.value;
   }
 
+  // Using componentWillLoad instead of connectedCallback() here to fix
+  // a bug caused by a race condition. Refer to COMUI-541 for details
   componentWillLoad(): void {
     this.input = this.root.querySelector('input[slot="input"]');
     this.disabled = this.input.disabled;


### PR DESCRIPTION
Addresses bug for ticket COMUI-541 

Somehow a change in [COMUI-437: Remove gux-checkbox-legacy dependency from gux-row-select](https://inindca.atlassian.net/browse/COMUI-437) caused an issue in the gux-input-range component in the deployed webcomponents docs and Spark site. I can't find why that PR would have caused an issue with the gux-input-range component as it is not immediately apparent. To complicate things further, the bug cannot be reproduced locally, only when deployed in a feature branch.

The gux-input-range component was trying to reference the input before it was defined and as a result the component was not functional

There are two ways to fix this bug. One is to revert the changes in COMUI-437 (the revert is in the branch feature/COMUI-541-revert-bug) and then try to identify the root cause of what may have caused the issue. The other option is to merge this PR.

Broken: https://apps.inindca.com/common-ui-docs/genesys-webcomponents/2.22.2/#gux-input-range
Fixed (feature branch): https://apps.inindca.com/common-ui-docs/genesys-webcomponents/feature/COMUI-541/#gux-input-range