### PR TITLE
fix(attributes-panel): boolean attributes will now appear as checkboxes properly

### DIFF
--- a/docs/src/component-viewer/components/checkbox-attribute.js
+++ b/docs/src/component-viewer/components/checkbox-attribute.js
@@ -1,17 +1,25 @@
 import { toHTML } from '../../utils/to-html';
 
 export const checkboxAttribute = (name, astNode, parent, renderCallback) => {
-  let matchingAttr = astNode.attrs.find(a => a.name === name);
+  const matchingAttr = astNode.attrs.find(a => a.name === name);
 
-  let element = toHTML(`
+  const randomHTMLId = prefix => {
+    return `${prefix}-${Math.random().toString(36).substr(2, 10)}`;
+  };
+
+  const checkboxId = randomHTMLId('docs-checkbox');
+  const isChecked =
+    matchingAttr && matchingAttr.value === 'true' ? 'checked' : '';
+
+  const element = toHTML(`
     <gux-form-field>
-      <input slot="input" type="checkbox" value="${name}"}>
-      <label slot="label">${name}:</label>
+      <input slot="input" type="checkbox" value="${name}" id="${checkboxId}" ${isChecked}>
+      <label slot="label" for="${checkboxId}">${name}:</label>
     </gux-form-field>`);
 
   element.addEventListener('change', ({ target }) => {
     if (target.checked) {
-      astNode.attrs.push({ name: name, value: '' });
+      astNode.attrs.push({ name: name, value: 'true' });
     } else {
       astNode.attrs = astNode.attrs.filter(attr => attr.name !== name);
     }

--- a/scripts/generate-component-data.js
+++ b/scripts/generate-component-data.js
@@ -98,7 +98,7 @@ function parseAttributeTable(mdStr) {
 }
 
 function attributeType(type) {
-  if (type == 'Boolean') {
+  if (type == 'boolean') {
     return 'checkbox';
   } else if (type.startsWith('string') || type == 'number') {
     return 'text';


### PR DESCRIPTION
Previously boolean attributes were displayed as dropdowns. This is now fixed and it appears as checkboxes properly.

### After Fix:
`boolean` attribute with checkboxes

![image](https://user-images.githubusercontent.com/5516663/123997041-9417db00-d9ed-11eb-8824-ed01866bc577.png)


### Before Fix:
![image](https://user-images.githubusercontent.com/5516663/123996930-7b0f2a00-d9ed-11eb-8c23-e985a3212379.png)


