### PR TITLE
fix(gux-input-number): number input is now aligned to the right

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-input-number/gux-input-number.less
+++ b/src/components/stable/gux-form-field/components/gux-input-number/gux-input-number.less
@@ -45,6 +45,7 @@ gux-input-number {
         align-self: auto;
         order: 0;
         color: @gux-black-50;
+        text-align: right;
         background-color: @gux-grey-90;
         border: none;
         outline: none;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/5516663/127106340-d682a1d8-8c7e-4b35-8d12-47afce8d0316.png)

![image](https://user-images.githubusercontent.com/5516663/127106351-87a0961d-de1b-45d0-b0eb-1a0cc930249e.png)

# Legacy vs form-field
![image](https://user-images.githubusercontent.com/5516663/127106252-3a415a81-91d2-4902-8c25-7483d5915afd.png)
