### PR TITLE
chore(translations): translation updates

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/cs.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/cs.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Povinné"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/da.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/da.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Påkrævet"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/de.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/de.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Erforderlich"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/es-es.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/es-es.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Obligatorio"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/es.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/es.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Obligatorio"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/fi.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/fi.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Pakollinen"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/fr-ca.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/fr-ca.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Requis"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/fr.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/fr.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Requis"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/it.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/it.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Richiesto"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/ja.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/ja.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "必須"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/ko.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/ko.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "요구됨"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/nl.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/nl.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Vereist"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/no.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/no.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Obligatorisk"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/pl.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/pl.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Wymagane"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/pt-br.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/pt-br.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Obrigatório"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/ru.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/ru.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Обязательно"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/sv.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/sv.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Obligatoriskt"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/th.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/th.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "จำเป็น"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/tr.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/tr.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "Gerekli"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-cn.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-cn.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "必需"
 }

--- a/src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-tw.json
+++ b/src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-tw.json
@@ -1,3 +1,3 @@
 {
-  "required": "Required"
+  "required": "必需"
 }


### PR DESCRIPTION
Translation Process Automation generated string (DO NOT EDIT): [src/components/stable/gux-form-field/components/gux-input-color/i18n/cs.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/da.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/de.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/es-es.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/es.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/fi.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/fr-ca.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/fr.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/it.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/ja.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/ko.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/nl.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/no.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/pl.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/pt-br.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/ru.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/sv.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/th.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/tr.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-cn.json,src/components/stable/gux-form-field/components/gux-input-color/i18n/zh-tw.json]