### PR TITLE
fix(gux-button): align icon and text

### DIFF
--- a/src/components/stable/gux-button/gux-button.less
+++ b/src/components/stable/gux-button/gux-button.less
@@ -92,6 +92,7 @@ gux-button {
 
     > * {
       padding-left: @spacing-2xs;
+      vertical-align: middle;
     }
 
     > *:first-child {


### PR DESCRIPTION
COMUI-566 -- Fixed alignment of icons and text in gux-button. Does not break styling of buttons with multiple spans or text overflow ellipsis.

Before:
![image](https://user-images.githubusercontent.com/82100934/129251232-d1f97c62-5e62-4125-ae79-3030d5741b9d.png)

After:
![image](https://user-images.githubusercontent.com/82100934/129251151-597feddb-ebdc-42fa-b585-c687888e923e.png)
