### PR TITLE
feat(button): add method for programatically focusing

### DIFF
--- a/src/components/stable/gux-button/gux-button.tsx
+++ b/src/components/stable/gux-button/gux-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, JSX, Prop } from '@stencil/core';
+import { Component, Element, h, JSX, Method, Prop } from '@stencil/core';
 
 import { trackComponent } from '../../../usage-tracking';
 import { GuxButtonAccent, GuxButtonType } from './gux-button.types';
@@ -40,6 +40,14 @@ export class GuxButton {
    */
   @Prop()
   accent: GuxButtonAccent = 'secondary';
+
+  /**
+   * Focus the button
+   */
+  @Method()
+  async focusElement() {
+    this.root.querySelector('button').focus();
+  }
 
   componentWillLoad() {
     trackComponent(this.root, { variant: this.accent });

--- a/src/components/stable/gux-button/readme.md
+++ b/src/components/stable/gux-button/readme.md
@@ -17,6 +17,19 @@ You can choose between two type (secondary and primary).
 | `type`     | `type`      | The component button type                    | `"button" \| "reset" \| "submit"`        | `'button'`    |
 
 
+## Methods
+
+### `focusElement() => Promise<void>`
+
+Focus the button
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Dependencies
 
 ### Used by

--- a/src/components/stable/gux-button/tests/gux-button.e2e.ts
+++ b/src/components/stable/gux-button/tests/gux-button.e2e.ts
@@ -99,4 +99,17 @@ describe('gux-button', () => {
       expect(onClickSpy).toHaveReceivedEventTimes(0);
     });
   });
+  describe('focus', () => {
+    it('should be programmatically focusable', async () => {
+      const html = '<gux-button>Button</gux-button>';
+      const page = await newE2EPage({ html });
+      const element = await page.find('gux-button');
+
+      await element.callMethod('focusElement');
+      const focusedElement = await page.evaluateHandle(
+        () => document.activeElement.nodeName
+      );
+      expect(await focusedElement.jsonValue()).toBe('BUTTON');
+    });
+  });
 });


### PR DESCRIPTION
Adds a `focusElement` API on the `gux-button` component.