### PR TITLE
Better aria behavior for modal - trap focus and dismiss via escape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4722,7 +4722,7 @@
     },
     "add-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/add-stream/-/add-stream-1.0.0.tgz",
       "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
@@ -6309,7 +6309,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -7690,6 +7690,14 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "focus-trap": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.6.1.tgz",
+      "integrity": "sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==",
+      "requires": {
+        "tabbable": "^5.2.1"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/for-in/-/for-in-1.0.2.tgz",
@@ -7718,7 +7726,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -7920,7 +7928,7 @@
     },
     "git-remote-origin-url": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
@@ -7940,7 +7948,7 @@
     },
     "gitconfiglocal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
@@ -8027,7 +8035,7 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
       "dev": true
     },
@@ -10561,7 +10569,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -10996,7 +11004,7 @@
     },
     "lodash.ismatch": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
       "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
       "dev": true
     },
@@ -11723,13 +11731,13 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
@@ -11753,13 +11761,13 @@
     },
     "null-check": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/null-check/-/null-check-1.0.0.tgz",
       "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
       "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
@@ -12102,7 +12110,7 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
@@ -12228,13 +12236,13 @@
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
       "dev": true
     },
@@ -13689,7 +13697,7 @@
       "dependencies": {
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         }
@@ -13745,7 +13753,7 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
     },
@@ -14179,7 +14187,7 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
@@ -14211,6 +14219,11 @@
       "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
+    },
+    "tabbable": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
+      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
     },
     "table": {
       "version": "6.6.0",
@@ -14741,7 +14754,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://purecloud.jfrog.io/purecloud/api/npm/inin-internal-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.9.3",
+    "focus-trap": "^6.6.1",
     "intl-messageformat": "~9.4.9",
     "requestanimationframe-timer": "^3.0.3",
     "sortablejs": "^1.14.0",

--- a/src/components/beta/gux-dismiss-button/gux-dismiss-button.tsx
+++ b/src/components/beta/gux-dismiss-button/gux-dismiss-button.tsx
@@ -9,7 +9,7 @@ import translationResources from './i18n/en.json';
 @Component({
   styleUrl: 'gux-dismiss-button.less',
   tag: 'gux-dismiss-button-beta',
-  shadow: true
+  shadow: { delegatesFocus: true }
 })
 export class GuxDismissButton {
   private i18n: GetI18nValue;

--- a/src/components/stable/gux-button/gux-button.tsx
+++ b/src/components/stable/gux-button/gux-button.tsx
@@ -6,6 +6,9 @@ import { GuxButtonAccent, GuxButtonType } from './gux-button.types';
 @Component({
   styleUrl: 'gux-button.less',
   tag: 'gux-button'
+  // NOTE: In the future if we migrate this to shadowDOM, `delegatesFocus` so .focus() works
+  //   This will let us remove a workaround for gux-buttons in gux-modal.
+  // shadow: { delegatesFocus: true }
 })
 export class GuxButton {
   @Element()

--- a/src/components/stable/gux-modal/example.html
+++ b/src/components/stable/gux-modal/example.html
@@ -17,14 +17,14 @@
     accent="primary"
     onClick='(function() {
         const html = window.toHTML(`
-            <gux-modal size="small">
+            <gux-modal initial-focus="#cancel-button" size="small">
                 <div slot="title">Modal Title</div>
                 <div slot="content">This contains the modal content.</div>
                 <div slot="left-align-buttons">
                     <gux-button title="Accept" accent="primary">Accept</gux-button>
                 </div>
                 <div slot="right-align-buttons">
-                    <gux-button title="Cancel">Cancel</gux-button>
+                    <gux-button id="cancel-button" title="Cancel">Cancel</gux-button>
                 </div>
             </gux-modal>
         `);

--- a/src/components/stable/gux-modal/gux-modal.tsx
+++ b/src/components/stable/gux-modal/gux-modal.tsx
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   h,
   JSX,
+  Listen,
   Prop
 } from '@stencil/core';
 import { createFocusTrap, FocusTrap } from 'focus-trap';
@@ -34,6 +35,13 @@ export class GuxModal {
    */
   @Event()
   guxdismiss: EventEmitter<void>;
+
+  @Listen('keydown')
+  protected handleKeyEvent(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      this.onDismissHandler(event);
+    }
+  }
 
   /**
    * Query selector for the element to initially focus when the modal opens
@@ -79,7 +87,7 @@ export class GuxModal {
       <div class="gux-modal">
         <div class={`gux-modal-container gux-${this.size}`}>
           <gux-dismiss-button-beta
-            onClick={this.onDismissClickHandler.bind(this)}
+            onClick={this.onDismissHandler.bind(this)}
           ></gux-dismiss-button-beta>
 
           {hasModalTitleSlot && (
@@ -126,7 +134,7 @@ export class GuxModal {
     );
   }
 
-  private onDismissClickHandler(event: MouseEvent): void {
+  private onDismissHandler(event: Event): void {
     event.stopPropagation();
 
     const dismissEvent = this.guxdismiss.emit();

--- a/src/components/stable/gux-modal/gux-modal.tsx
+++ b/src/components/stable/gux-modal/gux-modal.tsx
@@ -35,11 +35,19 @@ export class GuxModal {
   @Event()
   guxdismiss: EventEmitter<void>;
 
+  /**
+   * Query selector for the element to initially focus when the modal opens
+   * Defaults to the first tabbable element.
+   */
+  @Prop()
+  initialFocus?: string | undefined;
+
   private focusTrap: FocusTrap | undefined;
   componentDidLoad() {
     this.focusTrap = createFocusTrap(this.root, {
       escapeDeactivates: false,
-      returnFocusOnDeactivate: true
+      returnFocusOnDeactivate: true,
+      initialFocus: this.initialFocus
     });
     this.focusTrap.activate();
   }

--- a/src/components/stable/gux-modal/gux-modal.tsx
+++ b/src/components/stable/gux-modal/gux-modal.tsx
@@ -63,7 +63,8 @@ export class GuxModal {
     this.focusTrap = createFocusTrap(this.root, {
       escapeDeactivates: false,
       returnFocusOnDeactivate: true,
-      initialFocus
+      initialFocus,
+      fallbackFocus: () => this.root.querySelector('gux-dismiss-button-beta')
     });
     this.focusTrap.activate();
   }

--- a/src/components/stable/gux-modal/gux-modal.tsx
+++ b/src/components/stable/gux-modal/gux-modal.tsx
@@ -37,17 +37,25 @@ export class GuxModal {
 
   /**
    * Query selector for the element to initially focus when the modal opens
-   * Defaults to the first tabbable element.
+   * Defaults to the first tabbable element
    */
   @Prop()
   initialFocus?: string | undefined;
 
   private focusTrap: FocusTrap | undefined;
   componentDidLoad() {
+    // Workaround that gux-buttons don't have a native focus method that works
+    // Query the element then find the inner tabbable element
+    let initialFocus = this.initialFocus
+      ? this.root.querySelector<HTMLElement | SVGElement>(this.initialFocus)
+      : undefined;
+    if (initialFocus?.tagName === 'GUX-BUTTON') {
+      initialFocus = initialFocus.querySelector('button');
+    }
     this.focusTrap = createFocusTrap(this.root, {
       escapeDeactivates: false,
       returnFocusOnDeactivate: true,
-      initialFocus: this.initialFocus
+      initialFocus
     });
     this.focusTrap.activate();
   }

--- a/src/components/stable/gux-modal/gux-modal.tsx
+++ b/src/components/stable/gux-modal/gux-modal.tsx
@@ -7,7 +7,7 @@ import {
   JSX,
   Prop
 } from '@stencil/core';
-
+import { createFocusTrap, FocusTrap } from 'focus-trap';
 import { trackComponent } from '../../../usage-tracking';
 
 import { GuxModalSize } from './gux-modal.types';
@@ -34,6 +34,19 @@ export class GuxModal {
    */
   @Event()
   guxdismiss: EventEmitter<void>;
+
+  private focusTrap: FocusTrap | undefined;
+  componentDidLoad() {
+    this.focusTrap = createFocusTrap(this.root, {
+      escapeDeactivates: false,
+      returnFocusOnDeactivate: true
+    });
+    this.focusTrap.activate();
+  }
+  disconnectedCallback() {
+    this.focusTrap?.deactivate();
+    this.focusTrap = undefined;
+  }
 
   @Element()
   private root: HTMLElement;

--- a/src/components/stable/gux-modal/readme.md
+++ b/src/components/stable/gux-modal/readme.md
@@ -7,9 +7,10 @@ This default behaviour of this componet assumes that `gux-modal` components will
 
 ## Properties
 
-| Property | Attribute | Description                                              | Type                                          | Default     |
-| -------- | --------- | -------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `size`   | `size`    | Indicates the size of the modal (small, medium or large) | `"dynamic" \| "large" \| "medium" \| "small"` | `'dynamic'` |
+| Property       | Attribute       | Description                                                                                                   | Type                                          | Default     |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `initialFocus` | `initial-focus` | Query selector for the element to initially focus when the modal opens Defaults to the first tabbable element | `string`                                      | `undefined` |
+| `size`         | `size`          | Indicates the size of the modal (small, medium or large)                                                      | `"dynamic" \| "large" \| "medium" \| "small"` | `'dynamic'` |
 
 
 ## Events

--- a/src/components/stable/gux-modal/tests/gux-modal.e2e.ts
+++ b/src/components/stable/gux-modal/tests/gux-modal.e2e.ts
@@ -174,9 +174,9 @@ describe('gux-modal', () => {
       `;
       const page = await newE2EPage({ html });
       const element = await page.find('gux-modal');
-      const dismissButton = (await element.find(
+      const dismissButton = await element.find(
         'gux-dismiss-button-beta >>> button'
-      )) as HTMLElement;
+      );
       const guxdismissSpy = await page.spyOnEvent('guxdismiss');
       const clickSpy = await page.spyOnEvent('click');
 
@@ -196,6 +196,32 @@ describe('gux-modal', () => {
       expect(guxdismissSpy).toHaveReceivedEvent();
       expect(clickSpy).not.toHaveReceivedEvent();
       expect(await page.find('gux-modal')).not.toBeNull();
+    });
+
+    it('escape key dismiss', async () => {
+      const html = `
+        <gux-modal lang="en" size="small">
+          <div slot="title">Modal Title</div>
+          <div slot="content">This contains the modal content.</div>
+          <div slot="left-align-buttons">
+              <gux-button title="Cancel">Cancel</gux-button>
+          </div>
+          <div slot="right-align-buttons">
+            <gux-button title='Button' accent='primary'>Accept</gux-button>
+          </div>
+        </gux-modal>
+      `;
+      const page = await newE2EPage({ html });
+      const guxdismissSpy = await page.spyOnEvent('guxdismiss');
+
+      expect(guxdismissSpy).not.toHaveReceivedEvent();
+      expect(await page.find('gux-modal')).not.toBeNull();
+
+      await page.keyboard.down('Escape');
+      await page.waitForChanges();
+
+      expect(guxdismissSpy).toHaveReceivedEvent();
+      expect(await page.find('gux-modal')).toBeNull();
     });
   });
 });

--- a/src/components/stable/gux-modal/tests/gux-modal.spec.ts
+++ b/src/components/stable/gux-modal/tests/gux-modal.spec.ts
@@ -1,6 +1,17 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { GuxButton } from '../../gux-button/gux-button';
 import { GuxModal } from '../gux-modal';
+import { MockHTMLElement } from '@stencil/core/mock-doc';
+
+// Monkeypatch a missing function in the stencil mock docs
+if (!('getAttributeNode' in MockHTMLElement.prototype)) {
+  Object.assign(MockHTMLElement.prototype, {
+    // The implementation doesn't have to be right it just can't crash
+    getAttributeNode() {
+      return null;
+    }
+  });
+}
 
 const components = [GuxButton, GuxModal];
 const language = 'en';

--- a/src/components/stable/gux-modal/tests/gux-modal.spec.ts
+++ b/src/components/stable/gux-modal/tests/gux-modal.spec.ts
@@ -138,6 +138,9 @@ describe('gux-modal', () => {
         await page.waitForChanges();
 
         expect(page.root).toMatchSnapshot();
+
+        // Disconnect so that the focus trap is properly cleaned up
+        page.root!.remove();
       });
     });
   });
@@ -174,6 +177,8 @@ describe('gux-modal', () => {
       expect(guxdismissSpy).toHaveBeenCalled();
       expect(clickSpy).not.toHaveBeenCalled();
       expect(elementRemoveSpy).toBeCalledWith();
+
+      page.root!.remove();
     });
 
     it('click dismiss button and prevent default', async () => {
@@ -204,6 +209,8 @@ describe('gux-modal', () => {
       await page.waitForChanges();
 
       expect(elementRemoveSpy).not.toBeCalled();
+
+      page.root!.remove();
     });
   });
 });


### PR DESCRIPTION
Modifies `gux-modal` [to follow accessibility guidelines](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal) a little better.  

* Keyboard focus moves to the modal when it opens
* Keyboard focus is trapped in the modal - cannot focus an element outside the modal via keyboard navigation.
* Keyboard focus returns to the originally focused element when the modal closes
* Modal can be closed with the escape key

There's also an option for customizing the initial focus element if the first focusable element in the modal isn't the desired behavior.  (e.g. to select the least destructive action).

---

Two notes: 

* In this version the dismiss button isn't tabbable - (I think that's due to [how focus-trap detects tabbable elements](https://github.com/focus-trap/tabbable#more-details)).  I can make it explicitly tabbable with `tabIndex={0}`... but then it'll be the focused element by default in most cases, since it's the first element in the DOM, which I don't think is as nice as having the buttons at the bottom focused by default.  I'm not sure it needs to be tabbable since the 'close with escape' key behavior does the same logic.  

* Had to do some workaround to get gux-buttons to focus via the `initialFocus` prp, since the `.focus()` method doesn't work, which is what `focus-table` will use to try to focus the element.  If we switch the gux-button over to Shadow DOM that will make `.focus` work, (...but may cause tabbable issues similar to the dismiss button).