### PR TITLE
fix(gux-tooltip): remove cursor styling form linked element

### DIFF
--- a/src/components/beta/gux-tooltip-title/gux-tooltip-title.less
+++ b/src/components/beta/gux-tooltip-title/gux-tooltip-title.less
@@ -17,6 +17,3 @@ gux-tooltip-title-beta {
     }
   }
 }
-.gux-tooltip-for-element {
-  cursor: default !important;
-}

--- a/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -81,8 +81,6 @@ export class GuxTooltip {
 
   componentDidLoad(): void {
     if (this.forElement) {
-      // 'gux-tooltip-for-element' is defined in /src/style/style.less
-      this.forElement.classList.add('gux-tooltip-for-element');
       this.forElement.setAttribute('aria-describedby', this.id);
 
       this.popperInstance = createPopper(this.forElement, this.root, {
@@ -110,7 +108,6 @@ export class GuxTooltip {
   }
 
   disconnectedCallback(): void {
-    this.forElement.classList.remove('gux-tooltip-for-element');
     this.forElement.removeAttribute('aria-describedby');
 
     if (this.popperInstance) {

--- a/src/components/stable/gux-tooltip/tests/__snapshots__/gux-tooltip.spec.ts.snap
+++ b/src/components/stable/gux-tooltip/tests/__snapshots__/gux-tooltip.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`gux-tooltip #remove should remove component as expected (2) 1`] = `
 
 exports[`gux-tooltip #render should render component as expected (1) 1`] = `
 <body>
-  <div aria-describedby="gux-tooltip-i" class="gux-tooltip-for-element">
+  <div aria-describedby="gux-tooltip-i">
     <div>
       Element
     </div>
@@ -37,7 +37,7 @@ exports[`gux-tooltip #render should render component as expected (1) 1`] = `
 exports[`gux-tooltip #render should render component as expected (2) 1`] = `
 <body>
   <div>
-    <div aria-describedby="gux-tooltip-i" class="gux-tooltip-for-element" id="element">
+    <div aria-describedby="gux-tooltip-i" id="element">
       Element
     </div>
     <gux-tooltip for="element" id="gux-tooltip-i" role="tooltip" tabindex="0">

--- a/src/components/stable/gux-tooltip/tests/gux-tooltip.e2e.ts
+++ b/src/components/stable/gux-tooltip/tests/gux-tooltip.e2e.ts
@@ -27,7 +27,6 @@ describe('gux-tooltip', () => {
         const tooltip = await page.find('gux-tooltip');
 
         expect(element.getAttribute('aria-describedby')).toBe(tooltip.id);
-        expect(element).toHaveClass('gux-tooltip-for-element');
         expect(tooltip.getAttribute('data-popper-placement')).toBe(
           'bottom-start'
         );

--- a/src/style/style.less
+++ b/src/style/style.less
@@ -13,7 +13,3 @@ a {
 a:hover {
   text-decoration: underline;
 }
-
-.gux-tooltip-for-element {
-  cursor: pointer;
-}


### PR DESCRIPTION
Gux-tooltip was enforcing `cursor: pointer` styling on the linked element. Per discussion in standup, removed this styling to allow linked element to define its own cursor styles (ie `cursor: help` for a help tooltip).

The removed style was added during a component API change last year. Later this style was made `!important` related to the gux-tabs-beta. Did not notice any negative consequences of removing the style on the documentation for gux-tooltip or gux-tabs-beta. Hopefully, Daragh or Katie can remember what its original use was and verify no regression.

COMUI-653