### PR TITLE
fix(gux-icon): svg icon cache logic has been improved and reduced network calls

### DIFF
--- a/src/components/stable/gux-icon/example.html
+++ b/src/components/stable/gux-icon/example.html
@@ -63,6 +63,12 @@
   <gux-icon icon-name="align-center" decorative></gux-icon>
   <gux-icon icon-name="align-right" decorative></gux-icon>
 </div>
+<hr />
+<div>
+  <gux-icon icon-name="user" screenreader-text="user-01"></gux-icon>
+  <gux-icon icon-name="user" screenreader-text="user-02"></gux-icon>
+  <gux-icon icon-name="user" screenreader-text="user-03"></gux-icon>
+</div>
 <p>Duplicated icons should not require additional network calls</p>
 
 <h1>Spark Icons</h1>

--- a/src/components/stable/gux-icon/gux-icon.service.tsx
+++ b/src/components/stable/gux-icon/gux-icon.service.tsx
@@ -33,7 +33,7 @@ export function getRootIconName(iconName: string): string {
   return iconName;
 }
 
-export function getSvgHtml(iconName: string): Promise<string> {
+export function getBaseSvgHtml(iconName: string): Promise<string> {
   const id = iconInfoToId(iconName);
   const cachedSvgElement = svgHTMLCache.get(id);
 
@@ -48,7 +48,7 @@ export function getSvgHtml(iconName: string): Promise<string> {
         throw err;
       }, 0);
 
-      return getSvgHtml('unknown');
+      return getBaseSvgHtml('unknown');
     });
 
   svgHTMLCache.set(id, svgHtml);

--- a/src/components/stable/gux-icon/gux-icon.service.tsx
+++ b/src/components/stable/gux-icon/gux-icon.service.tsx
@@ -17,12 +17,8 @@ async function fetchIcon(iconName: string): Promise<string> {
   );
 }
 
-function iconinfoToId(
-  iconName: string,
-  decorative: boolean,
-  screenreaderText: string
-): string {
-  return `${iconName.replace('/', '-')}-${decorative}-${screenreaderText}`;
+function iconInfoToId(iconName: string): string {
+  return iconName.replace('/', '-');
 }
 
 export function getRootIconName(iconName: string): string {
@@ -37,12 +33,8 @@ export function getRootIconName(iconName: string): string {
   return iconName;
 }
 
-export function getSvgHtml(
-  iconName: string,
-  decorative: boolean,
-  screenreaderText: string
-): Promise<string> {
-  const id = iconinfoToId(iconName, decorative, screenreaderText);
+export function getSvgHtml(iconName: string): Promise<string> {
+  const id = iconInfoToId(iconName);
   const cachedSvgElement = svgHTMLCache.get(id);
 
   if (cachedSvgElement) {
@@ -50,27 +42,13 @@ export function getSvgHtml(
   }
 
   const svgHtml = fetchIcon(iconName)
-    .then(svgText => {
-      const svgElement = new DOMParser().parseFromString(
-        svgText,
-        'image/svg+xml'
-      ).firstChild as SVGElement;
-      if (decorative) {
-        svgElement.setAttribute('aria-hidden', String(decorative));
-      }
-
-      if (screenreaderText) {
-        svgElement.setAttribute('aria-label', screenreaderText);
-      }
-
-      return svgElement.outerHTML;
-    })
+    .then(svgText => svgText)
     .catch(err => {
       setTimeout(() => {
         throw err;
       }, 0);
 
-      return getSvgHtml('unknown', decorative, screenreaderText);
+      return getSvgHtml('unknown');
     });
 
   svgHTMLCache.set(id, svgHtml);

--- a/src/components/stable/gux-icon/gux-icon.tsx
+++ b/src/components/stable/gux-icon/gux-icon.tsx
@@ -40,11 +40,8 @@ export class GuxIcon {
     if (iconName) {
       const rootIconName = getRootIconName(iconName);
 
-      this.svgHtml = await getSvgHtml(
-        rootIconName,
-        this.decorative,
-        this.screenreaderText
-      );
+      const baseSvgHtml = await getSvgHtml(rootIconName);
+      this.svgHtml = this.getSvgWithAriaAttributes(baseSvgHtml);
     }
   }
 
@@ -61,6 +58,21 @@ export class GuxIcon {
         'No screenreader-text provided. Either provide a localized screenreader-text property or set `decorative` to true.'
       );
     }
+  }
+
+  getSvgWithAriaAttributes(svgText: string) {
+    const svgElement = new DOMParser().parseFromString(svgText, 'image/svg+xml')
+      .firstChild as SVGElement;
+
+    if (this.decorative) {
+      svgElement.setAttribute('aria-hidden', String(this.decorative));
+    }
+
+    if (this.screenreaderText) {
+      svgElement.setAttribute('aria-label', this.screenreaderText);
+    }
+
+    return svgElement.outerHTML;
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-icon/gux-icon.tsx
+++ b/src/components/stable/gux-icon/gux-icon.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, JSX, Prop, State, Watch } from '@stencil/core';
 import { trackComponent } from '../../../usage-tracking';
 import { logError } from '../../../utils/error/log-error';
 
-import { getSvgHtml, getRootIconName } from './gux-icon.service';
+import { getBaseSvgHtml, getRootIconName } from './gux-icon.service';
 
 @Component({
   assetsDirs: ['icons'],
@@ -40,7 +40,7 @@ export class GuxIcon {
     if (iconName) {
       const rootIconName = getRootIconName(iconName);
 
-      const baseSvgHtml = await getSvgHtml(rootIconName);
+      const baseSvgHtml = await getBaseSvgHtml(rootIconName);
       this.svgHtml = this.getSvgWithAriaAttributes(baseSvgHtml);
     }
   }
@@ -60,7 +60,7 @@ export class GuxIcon {
     }
   }
 
-  getSvgWithAriaAttributes(svgText: string) {
+  private getSvgWithAriaAttributes(svgText: string): string {
     const svgElement = new DOMParser().parseFromString(svgText, 'image/svg+xml')
       .firstChild as SVGElement;
 


### PR DESCRIPTION
Now only one network request is fired even if the screen-reader texts are different.

![image](https://user-images.githubusercontent.com/5516663/135611184-e931a4f6-044f-48c5-99a6-94d32a09300a.png)
