### PR TITLE
docs(docs): add accessibility section to docs sidebar in feature branches

### DIFF
--- a/docs/src/component-viewer/app.js
+++ b/docs/src/component-viewer/app.js
@@ -74,7 +74,10 @@ function createLayout() {
     console.log('axe-live setup completed');
   };
 
-  if (process.env.NODE_ENV === 'development') {
+  if (
+    process.env.NODE_ENV === 'development' ||
+    window.location.href.indexOf('feature') > -1
+  ) {
     console.log('Setting up axe-live tool');
     setupAccessibilityTool();
   }


### PR DESCRIPTION
Currently the accessibility section on the docs site is only shown in the development environment. Adding the ability to access the accessibility section while on a feature branch will be useful when verifying PRs