### PR TITLE
test(gux-dropdown-v2): fix failing snapshot test

### DIFF
--- a/src/components/beta/gux-dropdown-v2/tests/__snapshots__/gux-dropdown-v2.spec.ts.snap
+++ b/src/components/beta/gux-dropdown-v2/tests/__snapshots__/gux-dropdown-v2.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`gux-dropdown-menu-v2 #render should render as expected 1`] = `
   <mock:shadow-root>
     <gux-popup-beta>
       <button aria-expanded="false" aria-haspopup="listbox" class="gux-field-button" slot="target" type="button">
-        <div class="gux-selected-option">
+        <div class="gux-field-button-content">
           <div class="gux-placeholder">
             Select...
           </div>


### PR DESCRIPTION
Two PRs that affected the `gux-dropdown-v2` component merged within a short time period, and GitHub did not show a failing build until after the second PR was already merged to master.