### PR TITLE
fix(gux-icon): remap trade icon to use correct icon

### DIFF
--- a/src/components/stable/gux-icon/icon-name-map.ts
+++ b/src/components/stable/gux-icon/icon-name-map.ts
@@ -344,7 +344,6 @@ export const iconNameMap: Record<string, string> = {
   'ic-chevron-right': 'chevron-right',
   'ic-transfer': 'transfer',
   exchange: 'transfer',
-  trade: 'transfer',
 
   // Charts
   'ic-bar-graph-variable-1': 'graph-bar-horizontal',


### PR DESCRIPTION
The `trade` icon was being mapped to use the `transfer` icon. The `trade` icon should be using its own icon.