### PR TITLE
docs: add clarification about allowSyntheticDefaultImports vs. esModuleInterop

### DIFF
--- a/docs/migrations/v3/readme.md
+++ b/docs/migrations/v3/readme.md
@@ -3,7 +3,7 @@
 *This migration guide is open to anyone to edit. If you have migrated a component and think it would be helpful to others to document something you encountered please do so. We understand that at the moment because of the need to fork the repo the overhead of making a small contribution is high so feel free to raise an issue on the COMUI board instead it that is more convenient and a core team member will create the PR.*
 
 ## TLDR
-* Set the `allowSyntheticDefaultImports` compiler option  to `true` in the host apps tsconfig.json.
+* Set the `allowSyntheticDefaultImports` (or `esModuleInterop`) compiler option  to `true` in the host apps tsconfig.json.
 * rename `title` property to `gux-title` on instances of `gux-button`
 * remove `first-day-of-week` property from instances of `gux-calendar`
 * remove `first-day-of-week` property from instances of `gux-datepicker`
@@ -27,8 +27,9 @@
   * `gux-text-label-legacy` -> Contact the Core UI team if you need help migrating away from this component.
 
 ## Configuration
-Set the `allowSyntheticDefaultImports` compiler option  to "true" in your host apps tsconfig.json. Omitting this option will cause build errors in your app.
+Set the `allowSyntheticDefaultImports` compiler option  to "true" in your host apps tsconfig.json. Omitting this option will cause build errors in your app.  
 This new requirement is related to the a new dependency (vega-lite) which was added as part of our visualisation work.
+(`allowSyntheticDefaultImports: true` is implied by `esModuleInterop: true`, so if the `esModuleInterop` is already enabled, `allowSyntheticDefaultImports` does not need to be explicitly added)
 
 ## Stable Component Changes
 


### PR DESCRIPTION
If `esModuleInterop` is already enabled, `allowSyntheticDefaultImports` does not need to be enabled.  