### PR TITLE
fix(gux-tabs): update gux-tabs to match Spark guidelines

### DIFF
--- a/src/components/stable/gux-disclosure-button/readme.md
+++ b/src/components/stable/gux-disclosure-button/readme.md
@@ -7,11 +7,11 @@ This is a UI button component that is used to open or dismiss an associated pane
 
 ## Properties
 
-| Property   | Attribute  | Description                                   | Type                | Default                             |
-| ---------- | ---------- | --------------------------------------------- | ------------------- | ----------------------------------- |
-| `isOpen`   | `is-open`  | Used to open or close the disclosure panel    | `boolean`           | `false`                             |
-| `label`    | `label`    | Indicates the label for the disclosure button | `string`            | `translationResources.defaultLabel` |
-| `position` | `position` | Indicates the position of the button panel    | `"left" \| "right"` | `'left'`                            |
+| Property   | Attribute  | Description                                   | Type                | Default                                                                    |
+| ---------- | ---------- | --------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| `isOpen`   | `is-open`  | Used to open or close the disclosure panel    | `boolean`           | `false`                                                                    |
+| `label`    | `label`    | Indicates the label for the disclosure button | `string`            | `(translationResources as ILocalizedComponentResources)     .defaultLabel` |
+| `position` | `position` | Indicates the position of the button panel    | `"left" \| "right"` | `'left'`                                                                   |
 
 
 ## Events

--- a/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.less
+++ b/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.less
@@ -78,7 +78,6 @@ gux-tabs {
 
   .gux-scroll-button-container {
     display: flex;
-    background-color: @gux-off-tab-fill;
     border-radius: 4px;
 
     .gux-scroll-button {
@@ -88,6 +87,8 @@ gux-tabs {
       width: 28px;
       height: 40px;
       color: @gux-black-30;
+      cursor: pointer;
+      background-color: @gux-off-tab-fill;
       background-color: @gux-tabs-background;
       border: none;
       border-radius: 4px;
@@ -102,12 +103,17 @@ gux-tabs {
         outline: none;
       }
 
-      &:hover {
-        color: @gux-blue-60;
+      &:hover:not(:disabled) {
+        background-color: @gux-grey-50;
       }
 
-      &:active {
+      &:active:not(:disabled) {
         background-color: darken(@gux-tabs-background, 5%);
+      }
+
+      &:disabled {
+        cursor: default;
+        opacity: 50%;
       }
 
       &:focus-visible {

--- a/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.less
+++ b/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.less
@@ -94,13 +94,8 @@ gux-tabs {
       border-radius: 4px;
 
       gux-icon {
-        width: 10px;
-        height: 10px;
-      }
-
-      &:focus {
-        border: 3px solid @gux-blue-90;
-        outline: none;
+        width: 16px;
+        height: 16px;
       }
 
       &:hover:not(:disabled) {
@@ -114,10 +109,6 @@ gux-tabs {
       &:disabled {
         cursor: default;
         opacity: 50%;
-      }
-
-      &:focus-visible {
-        .focus-ring();
       }
     }
   }

--- a/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.tsx
+++ b/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.tsx
@@ -62,13 +62,13 @@ export class GuxTabList {
   }
 
   @Listen('hasVerticalScrollbar')
-  onHasVerticalScrollBar() {
-    void this.checkDisabledScrollButtons();
+  onHasVerticalScrollBar(): void {
+    this.checkDisabledScrollButtons();
   }
 
   @Listen('scroll', { capture: true })
   onScroll(): void {
-    void this.checkDisabledScrollButtons();
+    this.checkDisabledScrollButtons();
   }
 
   private resizeObserver?: ResizeObserver;
@@ -259,27 +259,14 @@ export class GuxTabList {
       const scrollLeft = scrollContainer.scrollLeft;
       const scrollLeftMax =
         scrollContainer.scrollWidth - scrollContainer.clientWidth;
-
-      if (scrollLeft === 0) {
-        this.isScrolledToBeginning = true;
-      } else if (scrollLeftMax - scrollLeft === 0) {
-        this.isScrolledToEnd = true;
-      } else {
-        this.isScrolledToBeginning = false;
-        this.isScrolledToEnd = false;
-      }
-    } else if (this.hasVerticalScrollbar) {
+      this.isScrolledToBeginning = scrollLeft === 0;
+      this.isScrolledToEnd = scrollLeftMax - scrollLeft === 0;
+    } else {
       const scrollTop = scrollContainer.scrollTop;
       const scrollTopMax =
         scrollContainer.scrollHeight - scrollContainer.clientHeight;
-      if (scrollTop === 0) {
-        this.isScrolledToBeginning = true;
-      } else if (scrollTopMax - scrollTop === 0) {
-        this.isScrolledToEnd = true;
-      } else {
-        this.isScrolledToBeginning = false;
-        this.isScrolledToEnd = false;
-      }
+      this.isScrolledToBeginning = scrollTop === 0;
+      this.isScrolledToEnd = scrollTopMax - scrollTop === 0;
     }
   }
 
@@ -353,14 +340,10 @@ export class GuxTabList {
   private getButtonDisabled(direction: string): boolean {
     switch (direction) {
       case 'scrollLeft':
-        return this.isScrolledToBeginning;
-
-      case 'scrollRight':
-        return this.isScrolledToEnd;
-
       case 'scrollUp':
         return this.isScrolledToBeginning;
 
+      case 'scrollRight':
       case 'scrollDown':
         return this.isScrolledToEnd;
     }

--- a/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.tsx
+++ b/src/components/stable/gux-tabs/gux-tab-list/gux-tab-list.tsx
@@ -61,6 +61,11 @@ export class GuxTabList {
     }
   }
 
+  @Listen('hasVerticalScrollbar')
+  onHasVerticalScrollBar() {
+    void this.checkDisabledScrollButtons();
+  }
+
   @Listen('scroll', { capture: true })
   onScroll(): void {
     void this.checkDisabledScrollButtons();
@@ -142,7 +147,6 @@ export class GuxTabList {
   }
 
   checkForScrollbarHideOrShow() {
-    this.checkDisabledScrollButtons();
     readTask(() => {
       const el = this.root.querySelector('.gux-scrollable-section');
       const hasHorizontalScrollbar = el.clientWidth !== el.scrollWidth;
@@ -155,6 +159,7 @@ export class GuxTabList {
       if (hasVerticalScrollbar !== this.hasVerticalScrollbar) {
         this.hasVerticalScrollbar = hasVerticalScrollbar;
       }
+      this.checkDisabledScrollButtons();
     });
   }
 
@@ -380,13 +385,13 @@ export class GuxTabList {
   private getChevronIconName(direction: string): string {
     switch (direction) {
       case 'scrollLeft':
-        return 'chevron-left';
+        return 'chevron-small-left';
       case 'scrollRight':
-        return 'chevron-right';
+        return 'chevron-small-right';
       case 'scrollUp':
-        return 'chevron-up';
+        return 'chevron-small-up';
       case 'scrollDown':
-        return 'chevron-down';
+        return 'chevron-small-down';
     }
   }
 }

--- a/src/components/stable/gux-tabs/gux-tab/gux-tab.less
+++ b/src/components/stable/gux-tabs/gux-tab/gux-tab.less
@@ -67,22 +67,6 @@ gux-tab {
   display: flex;
   max-width: 160px;
 
-  .gux-disabled {
-    gux-tooltip-title {
-      opacity: 50%;
-    }
-  }
-
-  gux-tooltip-title {
-    max-width: 160px;
-    overflow: hidden;
-    font-size: 14px;
-    color: @gux-type;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    cursor: default;
-  }
-
   .gux-tab {
     display: flex;
     align-items: center;
@@ -90,14 +74,34 @@ gux-tab {
     max-width: 160px;
     height: 40px;
     padding: 0 @spacing-medium;
+    cursor: pointer;
     background-color: #fff;
     border: none;
+
+    &.gux-disabled {
+      cursor: default;
+
+      gux-tooltip-title {
+        cursor: default;
+        opacity: 50%;
+      }
+    }
 
     &:focus-visible {
       padding: 0 13px 3px 13px;
       border: 3px solid @gux-blue-90;
       border-radius: 5px;
       outline: none;
+    }
+
+    gux-tooltip-title {
+      max-width: 160px;
+      overflow: hidden;
+      font-size: 14px;
+      color: @gux-type;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      cursor: pointer;
     }
   }
 }

--- a/src/components/stable/gux-tabs/gux-tab/gux-tab.less
+++ b/src/components/stable/gux-tabs/gux-tab/gux-tab.less
@@ -98,7 +98,7 @@ gux-tab {
       max-width: 160px;
       overflow: hidden;
       font-size: 14px;
-      color: @gux-type;
+      color: @gux-black-50;
       text-overflow: ellipsis;
       white-space: nowrap;
       cursor: pointer;


### PR DESCRIPTION
The main change was to disable the scroll button when at scroll start and end 

From UX:

After the Design System team reviewed the new gux-tabs-beta component, there were a couple fixes needed that we noticed.
* Use the hand cursor when hovering over a tab. 
* When hovering on the overflow arrow buttons, the behavior should align with what is currently implemented in the table component.
* Hover color on button should be Grey-50 
* Arrow icon color should not change to Blue-60 . 
* Disable overflow arrow button when you can't go any further to the left or right (up or down for vertical alignment), which is also similar behavior to what is in the table component. 
* Opacity of the button should be 50%