### PR TITLE
fix(gux-time-picker): give gux-time picker an aria-label attribute

### DIFF
--- a/src/components/beta/gux-time-picker/example.html
+++ b/src/components/beta/gux-time-picker/example.html
@@ -14,12 +14,13 @@
 </div>
 <h2>aria-label</h2>
 <span
-  >Providing a descriptive string for the gux-aria-label attribute is highly
-  recommended. If none is specified, the default is 'Time Picker'.</span
+  >Providing a descriptive string for the label attribute is highly recommended
+  for accessibility reasons. If none is specified, the default aria-label is
+  'Time Picker'.</span
 >
 <div>
   <gux-time-picker-beta
     value="03:40:32"
-    gux-aria-label="Lunch start time"
+    label="Lunch start time"
   ></gux-time-picker-beta>
 </div>

--- a/src/components/beta/gux-time-picker/example.html
+++ b/src/components/beta/gux-time-picker/example.html
@@ -1,9 +1,24 @@
+<h2>Set value</h2>
 <div>
   <gux-time-picker-beta value="03:40:32"></gux-time-picker-beta>
 </div>
+<h2>Min and max range</h2>
 <div>
   <gux-time-picker-beta min="02:00:00" max="22:00:00"></gux-time-picker-beta>
 </div>
+<h2>Interval</h2>
+<span>Default interval is 15</span>
 <div>
   <gux-time-picker-beta interval="10"></gux-time-picker-beta>
+</div>
+<h2>aria-label</h2>
+<span
+  >Providing a descriptive string for the gux-aria-label attribute is highly
+  recommended. If none is specified, the default is 'Time Picker'.</span
+>
+<div>
+  <gux-time-picker-beta
+    value="03:40:32"
+    gux-aria-label="Lunch start time"
+  ></gux-time-picker-beta>
 </div>

--- a/src/components/beta/gux-time-picker/gux-time-picker.tsx
+++ b/src/components/beta/gux-time-picker/gux-time-picker.tsx
@@ -45,7 +45,7 @@ export class GuxTimePicker {
   min: string = MIN_TIME;
 
   @Prop()
-  guxAriaLabel: string = '';
+  label: string = '';
 
   @State()
   active: boolean = false;
@@ -259,7 +259,7 @@ export class GuxTimePicker {
             value={this.value}
             size={9}
             class={this.active ? 'gux-focused' : ''}
-            aria-label={this.guxAriaLabel || this.i18n('defaultAriaLabel')}
+            aria-label={this.label || this.i18n('defaultAriaLabel')}
             ref={el => (this.inputElement = el)}
           ></input>
         </div>

--- a/src/components/beta/gux-time-picker/gux-time-picker.tsx
+++ b/src/components/beta/gux-time-picker/gux-time-picker.tsx
@@ -14,6 +14,10 @@ import {
 import { fromIsoTime } from '../../../utils/date/from-iso-time-string';
 import { trackComponent } from '../../../usage-tracking';
 
+import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
+
+import translationResources from './i18n/en.json';
+
 const MAX_TIME: string = '23:59:59';
 const MIN_TIME: string = '00:00:00';
 const DEFAULT_INTERVAL: number = 15;
@@ -23,6 +27,8 @@ const DEFAULT_INTERVAL: number = 15;
   tag: 'gux-time-picker-beta'
 })
 export class GuxTimePicker {
+  private i18n: GetI18nValue;
+
   @Element()
   root: HTMLElement;
 
@@ -37,6 +43,9 @@ export class GuxTimePicker {
 
   @Prop({ mutable: true })
   min: string = MIN_TIME;
+
+  @Prop()
+  guxAriaLabel: string = '';
 
   @State()
   active: boolean = false;
@@ -229,8 +238,9 @@ export class GuxTimePicker {
     return validatedValue;
   }
 
-  componentWillLoad() {
+  async componentWillLoad(): Promise<void> {
     trackComponent(this.root);
+    this.i18n = await buildI18nForComponent(this.root, translationResources);
     this.validateBounds();
     this.value = this.validateValue(this.value);
   }
@@ -249,6 +259,7 @@ export class GuxTimePicker {
             value={this.value}
             size={9}
             class={this.active ? 'gux-focused' : ''}
+            aria-label={this.guxAriaLabel || this.i18n('defaultAriaLabel')}
             ref={el => (this.inputElement = el)}
           ></input>
         </div>

--- a/src/components/beta/gux-time-picker/i18n/en.json
+++ b/src/components/beta/gux-time-picker/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "defaultAriaLabel": "Time Picker"
+}

--- a/src/components/beta/gux-time-picker/readme.md
+++ b/src/components/beta/gux-time-picker/readme.md
@@ -12,13 +12,13 @@ A check event is triggered when the state of the component changed.
 
 ## Properties
 
-| Property       | Attribute        | Description | Type     | Default            |
-| -------------- | ---------------- | ----------- | -------- | ------------------ |
-| `guxAriaLabel` | `gux-aria-label` |             | `string` | `''`               |
-| `interval`     | `interval`       |             | `number` | `DEFAULT_INTERVAL` |
-| `max`          | `max`            |             | `string` | `MAX_TIME`         |
-| `min`          | `min`            |             | `string` | `MIN_TIME`         |
-| `value`        | `value`          |             | `string` | `''`               |
+| Property   | Attribute  | Description | Type     | Default            |
+| ---------- | ---------- | ----------- | -------- | ------------------ |
+| `interval` | `interval` |             | `number` | `DEFAULT_INTERVAL` |
+| `label`    | `label`    |             | `string` | `''`               |
+| `max`      | `max`      |             | `string` | `MAX_TIME`         |
+| `min`      | `min`      |             | `string` | `MIN_TIME`         |
+| `value`    | `value`    |             | `string` | `''`               |
 
 
 ## Events

--- a/src/components/beta/gux-time-picker/readme.md
+++ b/src/components/beta/gux-time-picker/readme.md
@@ -12,12 +12,13 @@ A check event is triggered when the state of the component changed.
 
 ## Properties
 
-| Property   | Attribute  | Description | Type     | Default            |
-| ---------- | ---------- | ----------- | -------- | ------------------ |
-| `interval` | `interval` |             | `number` | `DEFAULT_INTERVAL` |
-| `max`      | `max`      |             | `string` | `MAX_TIME`         |
-| `min`      | `min`      |             | `string` | `MIN_TIME`         |
-| `value`    | `value`    |             | `string` | `''`               |
+| Property       | Attribute        | Description | Type     | Default            |
+| -------------- | ---------------- | ----------- | -------- | ------------------ |
+| `guxAriaLabel` | `gux-aria-label` |             | `string` | `''`               |
+| `interval`     | `interval`       |             | `number` | `DEFAULT_INTERVAL` |
+| `max`          | `max`            |             | `string` | `MAX_TIME`         |
+| `min`          | `min`            |             | `string` | `MIN_TIME`         |
+| `value`        | `value`          |             | `string` | `''`               |
 
 
 ## Events

--- a/src/components/beta/gux-time-picker/tests/gux-time-picker.e2e.ts
+++ b/src/components/beta/gux-time-picker/tests/gux-time-picker.e2e.ts
@@ -1,12 +1,6 @@
 import { newSparkE2EPage, a11yCheck } from '../../../../../tests/e2eTestUtils';
 
-const axeExclusions = [
-  {
-    issueId: 'label',
-    target: 'input',
-    exclusionReason: 'will be addressed in COMUI-733'
-  }
-];
+const axeExclusions = [];
 
 describe('gux-time-picker-beta', () => {
   it('renders', async () => {


### PR DESCRIPTION
COMUI-733

I think the best direction for the gux-time-picker would be to have some way to slot in a `label`, or to incorporate it into the gux-form-field component. Any ideas of what the future is for this component?

This solution is not the best, but allows users to provide a `gux-aria-label` attribute for the `gux-time-picker`. If no aria-label is provided, the default is 'Time Picker'