### PR TITLE
fix(css): added a secondary selector for button

### DIFF
--- a/src/components/stable/gux-button/gux-button.less
+++ b/src/components/stable/gux-button/gux-button.less
@@ -9,6 +9,23 @@ gux-button {
   pointer-events: none;
 
   > button {
+    // duplicated from base for increased specificity
+    > button.gux-secondary {
+      width: 100%;
+      height: 32px;
+      padding: 0 @spacing-medium;
+      overflow: hidden;
+      color: @gux-black-50;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      pointer-events: auto;
+      cursor: pointer;
+      background-color: @gux-grey-60;
+      border: none;
+      border-radius: 4px;
+      .body-font-bold();
+    }
+
     width: 100%;
     height: 32px;
     padding: 0 @spacing-medium;


### PR DESCRIPTION
To avoid css frameworks having more specific styles I added the &.gux-secondary selector.