### PR TITLE
fix(gux-dropdown): gux-dropdown within a gux-panel closes on scroll button click

### DIFF
--- a/src/components/stable/gux-dropdown/gux-dropdown.less
+++ b/src/components/stable/gux-dropdown/gux-dropdown.less
@@ -105,12 +105,12 @@ gux-dropdown {
       width: 100%;
       padding: 8px 0;
       margin-top: 2px;
+      overflow-y: auto;
       color: @gux-black-50;
       background: @gux-grey-100;
       border: 1px solid @gux-grey-30;
-      .gux-shadow-20();
-
       border-radius: 4px;
+      .gux-shadow-20();
 
       &.gux-opened {
         display: block;

--- a/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -133,12 +133,14 @@ export class GuxDropdown {
     const focusIndex = this.getFocusIndex(selectionOptions);
     switch (event.key) {
       case 'ArrowUp':
+        // prevent arrow key from triggering a page scroll
         event.preventDefault();
         if (focusIndex > 0) {
           selectionOptions[focusIndex - 1].focus();
         }
         break;
       case 'ArrowDown':
+        // prevent arrow key from triggering a page scroll
         event.preventDefault();
         if (this.inputIsFocused) {
           this.opened = true;

--- a/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -6,12 +6,12 @@ import {
   forceUpdate,
   h,
   JSX,
-  Listen,
   Method,
   Prop,
   State
 } from '@stencil/core';
 
+import { OnClickOutside } from '../../../utils/decorator/on-click-outside';
 import { whenEventIsFrom } from '../../../utils/dom/when-event-is-from';
 import { trackComponent } from '../../../usage-tracking';
 import { OnMutation } from '../../../utils/decorator/on-mutation';
@@ -74,8 +74,8 @@ export class GuxDropdown {
     this.change.emit(value);
   }
 
-  @Listen('focusout')
-  onFocusOut(e: FocusEvent) {
+  @OnClickOutside({ triggerEvents: 'mousedown' })
+  onClickOutside(e: MouseEvent) {
     if (!e.relatedTarget || !this.root.contains(e.relatedTarget as Node)) {
       this.opened = false;
       this.forcedGhostValue = '';
@@ -133,11 +133,13 @@ export class GuxDropdown {
     const focusIndex = this.getFocusIndex(selectionOptions);
     switch (event.key) {
       case 'ArrowUp':
+        event.preventDefault();
         if (focusIndex > 0) {
           selectionOptions[focusIndex - 1].focus();
         }
         break;
       case 'ArrowDown':
+        event.preventDefault();
         if (this.inputIsFocused) {
           this.opened = true;
         }
@@ -156,6 +158,14 @@ export class GuxDropdown {
           return;
         }
         selectionOptions[selectionOptions.length - 1].focus();
+        break;
+      case 'Escape':
+        this.textFieldElement.focus();
+        this.opened = false;
+        break;
+      case 'Tab':
+        this.textFieldElement.focus();
+        this.opened = false;
         break;
       case 'Enter':
       case 'Space':


### PR DESCRIPTION
COMUI-859
gux-dropdown within a gux-panel closes when the gux-dropdown's scroll button is clicked. If this PR looks good, I will create the v2 backport PR.

Code to recreate bug:
```
<gux-tabs class="example" active-tab="1-1">
    <gux-tab-list slot="tab-list">
        <gux-tab tab-id="1-1">
            <span>Tab Header 1</span>
        </gux-tab>
    </gux-tab-list>
    <gux-tab-panel tab-id="1-1">
        <gux-dropdown placeholder="Select..." filterable="true">
            <gux-option>1</gux-option>
            <gux-option>2</gux-option>
            <gux-option>3</gux-option>
            <gux-option>4</gux-option>
            <gux-option>5</gux-option>
            <gux-option>6</gux-option>
            <gux-option>7</gux-option>
            <gux-option>8</gux-option>
            <gux-option>9</gux-option>
            <gux-option>10</gux-option>
            <gux-option>11</gux-option>
            <gux-option>12</gux-option>
            <gux-option>13</gux-option>
            <gux-option>14</gux-option>
            <gux-option>15</gux-option>
            <gux-option>16</gux-option>
        </gux-dropdown>

    </gux-tab-panel>
</gux-tabs>
  
<style>
  .gux-options {
    height: 100px;
    overflow: auto;
  }
</style>
```


