### PR TITLE
fix(gux-tab-panel): fixed tabpanel outline bug in safari

### DIFF
--- a/src/components/stable/gux-tabs-advanced/gux-tab-advanced-panel/gux-tab-advanced-panel.less
+++ b/src/components/stable/gux-tabs-advanced/gux-tab-advanced-panel/gux-tab-advanced-panel.less
@@ -1,3 +1,13 @@
-gux-tab-panel {
-  -custom-noop: noop;
+@import (reference) '../../../../style/mixins.less';
+
+gux-tab-advanced-panel {
+  div[role='tabpanel'] {
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      .focus-ring();
+    }
+  }
 }

--- a/src/components/stable/gux-tabs/gux-tab-panel/gux-tab-panel.less
+++ b/src/components/stable/gux-tabs/gux-tab-panel/gux-tab-panel.less
@@ -1,3 +1,13 @@
+@import (reference) '../../../../style/mixins.less';
+
 gux-tab-panel {
-  -custom-noop: noop;
+  div[role='tabpanel'] {
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      .focus-ring();
+    }
+  }
 }


### PR DESCRIPTION
COMUI-846

Safari handles focus styling differently from Chrome and Firefox. If this PR looks good I can create the v2 backport PR as well