### PR TITLE
fix(gux-tab-panel-beta): fixed tabpanel outline shown on click in safari

### DIFF
--- a/src/components/beta/gux-tabs-beta/gux-tab-panel-beta/gux-tab-panel-beta.less
+++ b/src/components/beta/gux-tabs-beta/gux-tab-panel-beta/gux-tab-panel-beta.less
@@ -1,3 +1,13 @@
+@import (reference) '../../../../style/mixins.less';
+
 gux-tab-panel-beta {
-  -custom-noop: noop;
+  div[role='tabpanel'] {
+    &:focus {
+      outline: none;
+    }
+
+    &:focus-visible {
+      .focus-ring();
+    }
+  }
 }


### PR DESCRIPTION
COMUI-846 backport to v2