### PR TITLE
fix(gux-tooltip-title): long text no longer overflows tab tooltip

### DIFF
--- a/src/components/stable/gux-tabs/example.html
+++ b/src/components/stable/gux-tabs/example.html
@@ -11,13 +11,19 @@
       <span>Tab Header 2</span>
     </gux-tab>
     <gux-tab tab-id="1-3">
-      <span>Tab Header 3</span>
+      <span>Tab Header 3 long long long</span>
     </gux-tab>
     <gux-tab tab-id="1-4">
-      <span>Tab Header 4</span>
+      <span
+        >Tab Header 4 really long long long long long long long long long long
+        long long long</span
+      >
     </gux-tab>
     <gux-tab tab-id="1-5">
-      <span>Tab Header 5</span>
+      <span
+        >Tab Header 5
+        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong</span
+      >
     </gux-tab>
     <gux-tab tab-id="1-6">
       <span>Tab Header 6</span>

--- a/src/components/stable/gux-tooltip-title/gux-tooltip-title.less
+++ b/src/components/stable/gux-tooltip-title/gux-tooltip-title.less
@@ -3,6 +3,12 @@
 gux-tooltip-title {
   cursor: default;
 
+  gux-tooltip {
+    text-align: left;
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+
   .gux-title-container {
     display: flex;
 


### PR DESCRIPTION
COMUI-910
The tooltip for gux-tabs now wraps long text as expected


![image](https://user-images.githubusercontent.com/82100934/156065339-cf7233d3-125b-401f-a3a1-9bdb05d354dc.png)



**long word:**
![image](https://user-images.githubusercontent.com/82100934/156065388-c6812841-031e-498a-bef8-9aab31571972.png)
