### PR TITLE
fix(gux-tabs-beta): long text no longer overflows tab tooltip backport

### DIFF
--- a/src/components/beta/gux-tabs-beta/example.html
+++ b/src/components/beta/gux-tabs-beta/example.html
@@ -11,13 +11,19 @@
       <span>Tab Header 2</span>
     </gux-tab-beta>
     <gux-tab-beta tab-id="1-3">
-      <span>Tab Header 3</span>
+      <span>Tab Header 3 long long long</span>
     </gux-tab-beta>
     <gux-tab-beta tab-id="1-4">
-      <span>Tab Header 4</span>
+      <span
+        >Tab Header 4 really long long long long long long long long long long
+        long long long</span
+      >
     </gux-tab-beta>
     <gux-tab-beta tab-id="1-5">
-      <span>Tab Header 5</span>
+      <span
+        >Tab Header 5
+        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong</span
+      >
     </gux-tab-beta>
     <gux-tab-beta tab-id="1-6">
       <span>Tab Header 6</span>

--- a/src/components/beta/gux-tooltip-title/gux-tooltip-title.less
+++ b/src/components/beta/gux-tooltip-title/gux-tooltip-title.less
@@ -3,6 +3,12 @@
 gux-tooltip-title-beta {
   cursor: default;
 
+  gux-tooltip {
+    text-align: left;
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+
   .gux-title-container {
     display: flex;
 


### PR DESCRIPTION
COMUI-910
backport of https://github.com/MyPureCloud/genesys-webcomponents/pull/649