### PR TITLE
fix(gux-tabs-advanced): addressed a few remaining style issues

### DIFF
--- a/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.less
+++ b/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.less
@@ -10,16 +10,14 @@
 }
 
 gux-tab-advanced {
-  &:last-child {
-    .gux-tab {
-      .gux-tab-button {
-        border-right: none !important;
-      }
+  &:not(:last-child) .gux-tab:not(.gux-dropdown-options) {
+    .gux-tab-button {
+      border-right: 1px solid @gux-grey-50;
+    }
 
-      .gux-tab-options-button {
-        gux-icon {
-          border-right: none !important;
-        }
+    .gux-tab-options-button {
+      gux-icon {
+        border-right: 1px solid @gux-grey-50;
       }
     }
   }
@@ -42,6 +40,7 @@ gux-tab-advanced {
       height: 50px;
       padding-right: 0;
       padding-left: 16px;
+      color: #000;
       background-color: @gux-grey-90;
       border: none;
 
@@ -60,6 +59,7 @@ gux-tab-advanced {
         opacity: 0.5;
 
         .gux-tab-options-button {
+          color: @gux-black-50;
           pointer-events: none;
         }
       }
@@ -92,7 +92,6 @@ gux-tab-advanced {
         height: 30px;
         padding-right: 10px;
         padding-left: 8px;
-        border-right: 1px solid @gux-grey-50;
         transition: color 0.25s;
       }
     }
@@ -102,7 +101,6 @@ gux-tab-advanced {
         width: 160px;
         height: 30px;
         padding-right: 16px;
-        border-right: 1px solid @gux-grey-50;
 
         &:focus-visible {
           height: 90%;

--- a/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.tsx
+++ b/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.tsx
@@ -205,6 +205,7 @@ export class GuxTabAdvanced {
           class="gux-tab-options-button"
           onClick={() => this.toggleOptions()}
           tabIndex={this.active ? 0 : -1}
+          disabled={this.guxDisabled}
         >
           <gux-icon
             icon-name="menu-kebab-vertical"
@@ -253,13 +254,13 @@ export class GuxTabAdvanced {
           'gux-dropdown-options': this.hasDropdownOptions,
           'gux-disabled': this.guxDisabled
         }}
-        aria-disabled={this.guxDisabled.toString()}
       >
         <button
           class="gux-tab-button"
           type="button"
           role="tab"
           aria-selected={this.active.toString()}
+          aria-disabled={this.guxDisabled.toString()}
           aria-controls={`gux-${this.tabId}-panel`}
           ref={el => (this.buttonElement = el)}
           tabIndex={this.active ? 0 : -1}


### PR DESCRIPTION
COMUI-971
After merging the tab-advanced style changes into main, I noticed a few issues that I did not catch in the initial PR review.

- Fixed focus style for last tab in tablist
- Improved disabled tab behavior (keyboard)
- Changed tab and option button text color to match Spark design spec