### PR TITLE
Feature/com UI 977

### DIFF
--- a/src/components/beta/gux-chart-column/gux-chart-column.less
+++ b/src/components/beta/gux-chart-column/gux-chart-column.less
@@ -11,6 +11,6 @@ gux-visualization-beta {
   }
 
   .mark-rect.layer_1_marks path {
-    fill: #1da8b3;
+    fill: @gux-aqua-green-sec;
   }
 }

--- a/src/components/beta/gux-tag/gux-tag.less
+++ b/src/components/beta/gux-tag/gux-tag.less
@@ -98,7 +98,7 @@
   }
 
   &.gux-aqua-green {
-    color: @gux-black-40;
+    color: @gux-black-30;
     background-color: @gux-aqua-green-sec;
   }
 

--- a/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.less
+++ b/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.less
@@ -127,7 +127,7 @@ gux-tab-advanced {
     &.gux-selected {
       padding-bottom: 0;
       background-color: @gux-grey-100;
-      border-bottom: 2px solid #2a60c8;
+      border-bottom: 2px solid @gux-blue-60;
 
       .gux-tab-button {
         background-color: @gux-grey-100;

--- a/src/style/color-palette.less
+++ b/src/style/color-palette.less
@@ -15,26 +15,26 @@
 
 // Black
 @gux-black-10: #000000;
-@gux-black-20: #111315;
-@gux-black-30: #222529;
-@gux-black-40: #2b2f33;
-@gux-black-50: #33383d;
-@gux-black-60: #3c4148;
-@gux-black-70: #444a52;
-@gux-black-80: #555d66;
-@gux-black-90: #666f7b;
-@gux-black-100: #77828f;
+@gux-black-20: #151d28;
+@gux-black-30: #202937;
+@gux-black-40: #283243;
+@gux-black-50: #2e394c;
+@gux-black-60: #364154;
+@gux-black-70: #3e4a5b;
+@gux-black-80: #4c5667;
+@gux-black-90: #596373;
+@gux-black-100: #6b7585;
 
 // Grey
-@gux-grey-10: #9baab8;
-@gux-grey-20: #98a7b8;
-@gux-grey-30: #aeb9c6;
-@gux-grey-40: #c3cad4;
-@gux-grey-50: #d3dae2;
-@gux-grey-60: #e4e9f0;
-@gux-grey-70: #ebeef3;
-@gux-grey-80: #f1f3f5;
-@gux-grey-90: #f8f8f8;
+@gux-grey-10: #8a97ad;
+@gux-grey-20: #99a4b8;
+@gux-grey-30: #b4bccb;
+@gux-grey-40: #c8cfda;
+@gux-grey-50: #d7dce5;
+@gux-grey-60: #e2e6ee;
+@gux-grey-70: #e8ecf2;
+@gux-grey-80: #eff1f5;
+@gux-grey-90: #f6f7f9;
 @gux-grey-100: #fdfdfd;
 
 // Conditional Palette


### PR DESCRIPTION
Issue with aqua-green colour from the secondary colour palette was not passing accessibility checks with the new gux-black-40 text colour in the tag component. Updated to gux-black-30 for accessibility.