### PR TITLE
fix(form-field-v2): addition of gux-above class to label functional c…

### DIFF
--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-color/gux-form-field-color.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-color/gux-form-field-color.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(input) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-number/gux-form-field-number.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-number/gux-form-field-number.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(input) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-range/gux-form-field-range.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-range/gux-form-field-range.less
@@ -44,9 +44,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(input[type='range']) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-search/gux-form-field-search.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-search/gux-form-field-search.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(input) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-select/gux-form-field-select.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-select/gux-form-field-select.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(select) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-text-like/gux-form-field-text-like.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-text-like/gux-form-field-text-like.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(input) {

--- a/src/components/beta/gux-form-field-v2/components/gux-form-field-textarea/gux-form-field-textarea.less
+++ b/src/components/beta/gux-form-field-v2/components/gux-form-field-textarea/gux-form-field-textarea.less
@@ -20,9 +20,7 @@
 }
 
 ::slotted(label) {
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 20px;
+  .gux-label();
 }
 
 ::slotted(textarea) {

--- a/src/components/beta/gux-form-field-v2/functional-components/gux-form-field-label/gux-form-field-label.less
+++ b/src/components/beta/gux-form-field-v2/functional-components/gux-form-field-label/gux-form-field-label.less
@@ -1,5 +1,6 @@
 @import (reference) '../../../../../style/color-palette.less';
 @import (reference) '../../../../../style/typography.less';
+@import (reference) '../../../../../style/spacing.less';
 
 /* stylelint-disable-next-line selector-class-pattern */
 .GuxFormFieldLabelStyle {
@@ -17,7 +18,11 @@
       top: 7px;
       width: fit-content;
       min-width: 45px;
-      margin-right: 8px;
+      margin-right: @spacing-xs;
+    }
+
+    &.gux-above {
+      margin-bottom: @spacing-xs;
     }
 
     &.gux-screenreader {


### PR DESCRIPTION
**Description of issue**
The gux-form-field component in the genesys-webcomponents don't exactly follow the spark designs (should have 8px of spacing on the bottom if label is on top, and line-height of 16px instead of 20px).

**Resolution**
Addition of `gux-above` class to the label functional component styling which adds a `margin-bottom` of `8px`. Also amended the slotted labels on each form field component to have a line-height of 16px instead of 20px to match spark design doc. I did not change the line-heights on the radio and checkbox labels as there seems to be a custom config on it in relation to the icon.