### PR TITLE
fix(table): updating specific pixel sizes to set spacing variables

### DIFF
--- a/src/components/beta/gux-table/gux-table.light.less
+++ b/src/components/beta/gux-table/gux-table.light.less
@@ -1,4 +1,5 @@
 @import (reference) '../../../style/color.less';
+@import (reference) '../../../style/spacing.less';
 
 @gux-table-row-hover-selection: fade(@gux-blue-80, 24%);
 @gux-table-scroll-divider: fade(@gux-black-30, 10%);
@@ -18,8 +19,8 @@ gux-table-beta {
     th,
     td {
       height: 40px;
-      padding-right: 24px;
-      padding-left: 12px;
+      padding-right: @spacing-large;
+      padding-left: @spacing-small;
       text-align: left;
       border-color: @gux-grey-60;
       border-style: solid;
@@ -30,16 +31,16 @@ gux-table-beta {
     td[data-cell-numeric],
     th[data-cell-action],
     td[data-cell-action] {
-      padding-right: 12px;
-      padding-left: 24px;
+      padding-right: @spacing-small;
+      padding-left: @spacing-large;
       text-align: right;
     }
 
     tr[data-row-id] th,
     tr[data-row-id] td {
       width: 16px;
-      padding-right: 8px;
-      padding-left: 12px;
+      padding-right: @spacing-xs;
+      padding-left: @spacing-small;
     }
 
     th:last-child,
@@ -134,7 +135,7 @@ gux-table-beta {
 
       th:last-child,
       td:last-child {
-        padding-right: 48px;
+        padding-right: @spacing-3xl;
       }
     }
   }


### PR DESCRIPTION
Should I create a story for the cleanup of all beta components and create sub tasks for each component to update all hardcoded pixel sizes and utilise the spacing.less variables. The same goes with typography.