### PR TITLE
fix(datepicker) - implement popper js into datepicker component.

### DIFF
--- a/src/components/stable/gux-datepicker/gux-datepicker.less
+++ b/src/components/stable/gux-datepicker/gux-datepicker.less
@@ -117,8 +117,6 @@
       }
 
       gux-calendar {
-        position: absolute;
-        top: 30px;
         z-index: 1;
         display: none;
       }

--- a/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -44,6 +44,8 @@ import {
   getIntervalRange
 } from './gux-datepicker.service';
 
+import { createPopper, Instance } from '@popperjs/core';
+
 @Component({
   styleUrl: 'gux-datepicker.less',
   tag: 'gux-datepicker',
@@ -65,6 +67,8 @@ export class GuxDatepicker {
   startInputId: string = randomHTMLId('gux-datepicker');
   endInputId: string = randomHTMLId('gux-datepicker');
   i18n: GetI18nValue;
+
+  private popperInstance: Instance;
 
   @Element()
   root: HTMLElement;
@@ -649,6 +653,30 @@ export class GuxDatepicker {
 
   componentDidLoad() {
     this.updateDate();
+
+    this.popperInstance = createPopper(
+      this.datepickerElement,
+      this.calendarElement,
+      {
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0, -3]
+            }
+          }
+        ],
+        placement: 'bottom-start'
+      }
+    );
+  }
+
+  componentDidUpdate() {
+    this.popperInstance.forceUpdate();
+  }
+
+  disconnectedCallback(): void {
+    this.popperInstance.destroy();
   }
 
   renderCalendarToggleButton(): JSX.Element {

--- a/src/components/stable/gux-datepicker/tests/__snapshots__/gux-datepicker.spec.ts.snap
+++ b/src/components/stable/gux-datepicker/tests/__snapshots__/gux-datepicker.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`gux-datepicker #render should render component as expected (1) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
     </div>
@@ -38,7 +38,7 @@ exports[`gux-datepicker #render should render component as expected (2) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
     </div>
@@ -61,7 +61,7 @@ exports[`gux-datepicker #render should render component as expected (3) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
     </div>
@@ -84,7 +84,7 @@ exports[`gux-datepicker #render should render component as expected (4) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" value="1997-08-15" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
     </div>
@@ -107,7 +107,7 @@ exports[`gux-datepicker #render should render component as expected (5) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
       <div class="gux-datepicker-field">
@@ -143,7 +143,7 @@ exports[`gux-datepicker #render should render component as expected (6) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="2019-12-31" mindate="2019-11-10" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02"></gux-calendar>
+          <gux-calendar maxdate="2019-12-31" mindate="2019-11-10" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
       <div class="gux-datepicker-field">
@@ -179,7 +179,7 @@ exports[`gux-datepicker #render should render component as expected (7) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="2019-12-31" mindate="2019-11-10" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02"></gux-calendar>
+          <gux-calendar maxdate="2019-12-31" mindate="2019-11-10" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
       <div class="gux-datepicker-field">
@@ -215,7 +215,7 @@ exports[`gux-datepicker #render should render component as expected (8) 1`] = `
               <gux-icon decorative="" icon-name="calendar"></gux-icon>
             </button>
           </div>
-          <gux-calendar maxdate="" mindate="" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02"></gux-calendar>
+          <gux-calendar maxdate="" mindate="" mode="range" numberofmonths="2" value="2019-11-25/2019-12-02" style="position: absolute; left: 0; top: 0; margin: 0;"></gux-calendar>
         </div>
       </div>
       <div class="gux-datepicker-field">


### PR DESCRIPTION
**Description of issue:**
When opening the gux-calendar from gux-datepicker, the calendar shows up below the datepicker absolutely positioned. This will cause the entire control to be cut off when there is not enough vertical space in the container for the calendar to appear.

**Root cause analysis:**
The calendar component is positioned absolutely so if the container has not enough space the calender controls will be unavailable to the end user.

**Resolution:**
Implemented popper js within the datepicker component. The datepicker acts as a reference and the calender component acts as the popper element. If there is not enough space in the container the datepicker will either position itself above the reference or below the reference. Also added an offset of 8px between the reference and popper.