### PR TITLE
fix(gux-popover): fix z-index for Safari stacking context bug

### DIFF
--- a/src/components/beta/gux-popover-list/gux-popover-list.less
+++ b/src/components/beta/gux-popover-list/gux-popover-list.less
@@ -5,11 +5,11 @@
 @gux-arrow-height: 5px;
 
 :host {
-  z-index: 2;
   color: @gux-black-50;
 }
 
 .gux-popover-wrapper {
+  z-index: 2;
   display: inline-block;
   padding: @spacing-xs 0;
   background-color: @gux-grey-100;

--- a/src/components/stable/gux-popover/gux-popover.less
+++ b/src/components/stable/gux-popover/gux-popover.less
@@ -5,11 +5,11 @@
 @gux-arrow-height: 5px;
 
 :host {
-  z-index: 2;
   color: @gux-black-50;
 }
 
 .gux-popover-wrapper {
+  z-index: 2;
   display: inline-block;
   padding: @spacing-medium;
   background-color: @gux-grey-100;


### PR DESCRIPTION
COMUI-1022
Tab options in `gux-popover-list` were not showing properly in Safari only
![image](https://user-images.githubusercontent.com/82100934/166727733-8afed59d-7739-4ae0-9b7c-62c202a0a0f2.png)
