### PR TITLE
fix(table): applied currentTarget property to event object to retrieve parent element instead of child.

### DIFF
--- a/src/components/beta/gux-table/example.html
+++ b/src/components/beta/gux-table/example.html
@@ -373,7 +373,7 @@
     <thead>
       <tr>
         <th data-column-name="first-name" data-sortable data-sort="asc">
-          First name
+          <span>First name</span>
         </th>
         <th data-column-name="last-name">Last name</th>
         <th data-column-name="age" data-cell-numeric>Age</th>

--- a/src/components/beta/gux-table/gux-table.tsx
+++ b/src/components/beta/gux-table/gux-table.tsx
@@ -484,7 +484,7 @@ export class GuxTable {
       if (Object.prototype.hasOwnProperty.call(column.dataset, 'sortable')) {
         column.onclick = (event: MouseEvent) => {
           if (!this.columnResizeHover) {
-            const columnElement = event.target as HTMLElement;
+            const columnElement = event.currentTarget as HTMLElement;
             const sortDirection = columnElement.dataset.sort || '';
             let newSortDirection = null;
 

--- a/src/components/beta/gux-table/tests/gux-table.e2e.ts
+++ b/src/components/beta/gux-table/tests/gux-table.e2e.ts
@@ -133,4 +133,115 @@ describe('gux-table-beta', () => {
       });
     });
   });
+
+  it('should sort table if table header nested element is wrapped in a span tag', async () => {
+    const html = `<gux-table-beta lang="en">
+    <table slot="data">
+      <thead>
+        <tr>
+          <th data-column-name="first-name" data-sortable data-sort="asc">
+            <span>First name</span>
+          </th>
+          <th data-column-name="last-name">Last name</th>
+          <th data-column-name="age" data-cell-numeric>Age</th>
+          <th data-column-name="action" data-cell-action>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Adam</td>
+          <td>Ant</td>
+          <td data-cell-numeric>25</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Billy</td>
+          <td>Bat</td>
+          <td data-cell-numeric>28</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Cathy</td>
+          <td>Cat</td>
+          <td data-cell-numeric>21</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Debbie</td>
+          <td>Dog</td>
+          <td data-cell-numeric>23</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+      </tbody>
+    </table>
+  </gux-table-beta>`;
+
+    const page = await newE2EPage({ html });
+
+    const columnSortSpy = await page.spyOnEvent('guxsortchanged');
+    const headerElement = await page.find('th span');
+    await headerElement.click();
+    await page.waitForChanges();
+
+    expect(columnSortSpy).toHaveReceivedEventDetail({
+      columnName: 'first-name',
+      sortDirection: 'desc'
+    });
+  });
+
+  it('should sort table if table header nested element is not wrapped in a span tag', async () => {
+    const html = `<gux-table-beta lang="en">
+    <table slot="data">
+      <thead>
+        <tr>
+          <th data-column-name="first-name" data-sortable data-sort="asc">
+            First name
+          </th>
+          <th data-column-name="last-name">Last name</th>
+          <th data-column-name="age" data-cell-numeric>Age</th>
+          <th data-column-name="action" data-cell-action>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Adam</td>
+          <td>Ant</td>
+          <td data-cell-numeric>25</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Billy</td>
+          <td>Bat</td>
+          <td data-cell-numeric>28</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Cathy</td>
+          <td>Cat</td>
+          <td data-cell-numeric>21</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+        <tr>
+          <td>Debbie</td>
+          <td>Dog</td>
+          <td data-cell-numeric>23</td>
+          <td data-cell-action>Delete</td>
+        </tr>
+      </tbody>
+    </table>
+  </gux-table-beta>`;
+
+    const page = await newE2EPage({ html });
+
+    const columnSortEvent = await page.spyOnEvent('guxsortchanged');
+    const headerElement = await page.find('th');
+    await headerElement.click();
+
+    await page.waitForChanges();
+
+    expect(columnSortEvent).toHaveReceivedEventDetail({
+      columnName: 'first-name',
+      sortDirection: 'desc'
+    });
+  });
 });


### PR DESCRIPTION
**Description of issue :** 
For sortable columns in the gux-table component, if there is a child element in the sortable th element, and the user clicks on the child element, the guxsortchanged event does not contain the th's attributes for the columnName and sortDirection.

**RCA:**
In the table component the `columnElement` value was being set to `event.target` which was targeting the inner span tag if present instead of the parent `th` element. 

**Resolution:**
As a resolution to this I applied the `currentTarget` property to the event object instead of `target` property.
https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget

**View changes :** 
https://apps.inindca.com/common-ui-docs/genesys-webcomponents/feature/COMUI-1017