### PR TITLE
fix(table): if cursor is in resize state then dont perform sorting ac…

### DIFF
--- a/src/components/beta/gux-table/gux-table.tsx
+++ b/src/components/beta/gux-table/gux-table.tsx
@@ -483,24 +483,26 @@ export class GuxTable {
     columnsElements.forEach((column: HTMLElement) => {
       if (Object.prototype.hasOwnProperty.call(column.dataset, 'sortable')) {
         column.onclick = (event: MouseEvent) => {
-          const columnElement = event.target as HTMLElement;
-          const sortDirection = columnElement.dataset.sort || '';
-          let newSortDirection = null;
+          if (!this.columnResizeHover) {
+            const columnElement = event.target as HTMLElement;
+            const sortDirection = columnElement.dataset.sort || '';
+            let newSortDirection = null;
 
-          switch (sortDirection) {
-            case '':
-            case 'desc':
-              newSortDirection = 'asc';
-              break;
-            case 'asc':
-              newSortDirection = 'desc';
-              break;
+            switch (sortDirection) {
+              case '':
+              case 'desc':
+                newSortDirection = 'asc';
+                break;
+              case 'asc':
+                newSortDirection = 'desc';
+                break;
+            }
+
+            this.guxsortchanged.emit({
+              columnName: columnElement.dataset.columnName,
+              sortDirection: newSortDirection
+            });
           }
-
-          this.guxsortchanged.emit({
-            columnName: columnElement.dataset.columnName,
-            sortDirection: newSortDirection
-          });
         };
       }
     });


### PR DESCRIPTION
**Description of issue :**
In the gux-table component, if a column is both sortable and resizable, resizing the column via the mouse will also end up triggering the sorting on the column.

**RCA :**
Both resize and sorting actions are working off of the same element. The sorting action is done via an onClick event whereas the resize action is done via `mousedown` `mouseup` events. So if you were to resize for example after the mouseup event is executed the onClick event is scheduled in the background and will execute right after.

**Solution:**
Utilising the `columnResizeHover` state which will be `true` if the the mouse is in a position that supports the starting of a resize and thus not execute sorting action.

COMUI-1020