### PR TITLE
style(button, accordion, button-multi, action-button): set user-selec…

### DIFF
--- a/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.less
+++ b/src/components/stable/gux-accordion/gux-accordion-section/gux-accordion-section.less
@@ -5,6 +5,8 @@
 
 :host {
   color: @gux-black-50;
+  -webkit-user-select: none;
+  user-select: none;
   background-color: @gux-grey-100;
 
   &:first-child {

--- a/src/components/stable/gux-action-button/gux-action-button.less
+++ b/src/components/stable/gux-action-button/gux-action-button.less
@@ -4,6 +4,8 @@
 
 :host {
   display: block;
+  -webkit-user-select: none;
+  user-select: none;
   .body-font();
 }
 

--- a/src/components/stable/gux-button-multi/gux-button-multi.less
+++ b/src/components/stable/gux-button-multi/gux-button-multi.less
@@ -4,6 +4,8 @@
 
 :host {
   display: block;
+  -webkit-user-select: none;
+  user-select: none;
   .body-font();
 }
 

--- a/src/components/stable/gux-button/gux-button.less
+++ b/src/components/stable/gux-button/gux-button.less
@@ -7,6 +7,8 @@
   display: inline-block;
   min-width: 32px;
   pointer-events: none;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 :host(:focus) {


### PR DESCRIPTION
**Description of issue :**
We should prevent highlight of text on click for interactive elements. We should be able to use the `user-select` CSS property to fix this. 

Click or double click highlights text within some elements in Safari. It seems like updating to shadow dom has affected text highlight behavior in Safari. 

- accordion
- action-button
- button
- button-multi

**Resolution**
Added `webkit-user-select:none` to host of elements above which prevents issue.

COMUI-1036