### PR TITLE
build(publish): fix npmrc config for publishing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry="https://registry.npmjs.org/"
-//registry.npmjs.org/:_authToken=$NPM_TOKEN

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,11 +55,14 @@ webappPipeline {
           npm run lint
           npm run test.ci.spec
         ''')
-    }
-    buildStep = { assetPrefix ->
+
+        // Run in CI step so we only run once
+        // (builds happen twice, legacy and FedRAMP)
         if (isReleaseBranch()) {
             sh('npm run release')
         }
+    }
+    buildStep = { assetPrefix ->
         sh("""
           export CDN_URL=${assetPrefix}
           npm run build
@@ -72,6 +75,7 @@ webappPipeline {
               string(credentialsId: constants.credentials.npm,  variable: 'NPM_TOKEN')
             ]) {
                     sh('''
+                  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ./.npmrc
                   echo ".npmrc" >> .npmignore
                   npm publish
                 ''')


### PR DESCRIPTION
I think this should finally fix our NPM publishing credential issues. It's not as tidy as the previous approach, but it should work, as it's based on the IFC build process. 