### PR TITLE
ci(docs): don't skip build on commits from Jenkins

### DIFF
--- a/Docs.Jenkinsfile
+++ b/Docs.Jenkinsfile
@@ -25,7 +25,7 @@ def isPublicBranch = {
 }
 
 webappPipeline {
-    projectName = 'common-ui-docs/spark-components'
+    projectName = 'common-ui-docs/genesys-webcomponents'
     team = 'Core UI'
     mailer = 'CoreUI@genesys.com'
     nodeVersion = '14.x'
@@ -35,6 +35,7 @@ webappPipeline {
         sh('./scripts/generate-manifest')
         readJSON(file: 'docs-manifest.json')
     }
+    skipCommitsFrom = []
     buildType = {
         if(isReleaseBranch()) {
             return 'MAINLINE'
@@ -53,7 +54,7 @@ webappPipeline {
         }
         sh("""
           npm ci
-          export CDN_URL=${assetPrefix}
+          export DOCS_CDN_URL=${assetPrefix}
           npm run build
           npm run generate-versions-file
         """)


### PR DESCRIPTION
The docs build is only triggered by the component job, which handles avoiding build loops. The build
loop check here just causes mainline docs never to build due to the release commit from the
component build.

COMUI-1055


This depends on: https://bitbucket.org/inindca/pipeline-library/pull-requests/304/comui-1055-make-build-loop-check