### PR TITLE
fix(gux-toggle): change gux-toggle from display block to inline-block

### DIFF
--- a/src/components/stable/gux-toggle/example.html
+++ b/src/components/stable/gux-toggle/example.html
@@ -42,6 +42,12 @@
     label-position="left"
     error-message="This is another error message"
   ></gux-toggle>
+
+  <!-- inline gux-toggle -->
+  <div>
+    <gux-toggle checked-label="On" unchecked-label="Off"></gux-toggle>
+    <gux-toggle checked-label="On" unchecked-label="Off" checked></gux-toggle>
+  </div>
 </div>
 
 <style>

--- a/src/components/stable/gux-toggle/gux-toggle.less
+++ b/src/components/stable/gux-toggle/gux-toggle.less
@@ -2,7 +2,7 @@
 @import (reference) '../../../style/spacing.less';
 
 :host {
-  display: block;
+  display: inline-block;
   margin: 2px;
   color: @gux-black-50;
   outline: none;


### PR DESCRIPTION
[COMUI-1054](https://inindca.atlassian.net/browse/COMUI-1054)
Changing the gux-toggle from `display:block` to `display:inline-block` is not a complete solution to the problem. The error message and the area above the error message is still clickable. I think that to fully address the problem we will need to create a `gux-form-field-toggle` component that is functionally similar to the `gux-form-field-checkbox` component. Ticket here: https://inindca.atlassian.net/browse/COMUI-1059

Let me know if you have any other ideas of how to approach this