### PR TITLE
fix(build): fix assets url generation during build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,8 +63,16 @@ webappPipeline {
         }
     }
     buildStep = { assetPrefix ->
+        String cdnUrl = assetPrefix
+        // This is a bit of a kludge, but the build pipeline is intended for apps, which 
+        // can use relative URLs to load assets. Because the components are running inside
+        // apps, they have to load their assets from a full URL on the new UI hosting stack.
+        if (assetPrefix.startsWith('/')) {
+            cdnUrl = "https://app.mypurecloud.com${assetPrefix}genesys-webcomponents/"
+        }
+
         sh("""
-          export CDN_URL=${assetPrefix}
+          export CDN_URL=${cdnUrl}
           npm run build
         """)
     }


### PR DESCRIPTION
In moving to the new web pipeline to publish the component assets, we adopted the new cached asset
mechanism which uses applicaiton-relative paths to fetch assets. Since the components are not an
app, but are included in other apps, these paths were not correct. This changes the build so it will
use a fully qualified URL to look up assets.

COMUI-1063