### PR TITLE
fix(config): add experimentalImportInjection flag

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -76,5 +76,8 @@ export const config: Config = {
         }
       ]
     ]
+  },
+  extras: {
+    experimentalImportInjection: true
   }
 };


### PR DESCRIPTION
COMUI-1077
added `experimentalImportInjection` flag to fix lazy load issue with Vite bundler. 

Description of what flag does:
`Experimental flag. Projects that use a Stencil library built using the dist output target may have trouble lazily loading components when using a bundler such as Vite or Parcel. Setting this flag to true will change how Stencil lazily loads components in a way that works with additional bundlers. Setting this flag to true will increase the size of the compiled output. Defaults to false.`

I pulled down the repo that was experiencing the error with loading the stencil components using `vite`. I was able to reproduce the error.  I linked the `genesys-webcomponents` branch with the `experimentalImportInjection` flag set to `true` and it solved the reported problem.

Does anyone have suggestions of how to test to make sure this is not a breaking change for anyone?