### PR TITLE
bug(gux-calendar) - datepicker behaves wrongly when we move to the 31st of a month

### DIFF
--- a/src/components/stable/gux-calendar/gux-calendar.tsx
+++ b/src/components/stable/gux-calendar/gux-calendar.tsx
@@ -149,6 +149,7 @@ export class GuxCalendar {
 
   getMonthLabel(index: number) {
     const month = new Date(this.previewValue.getTime());
+    month.setDate(1);
     month.setMonth(month.getMonth() + index);
     const monthName = month.toLocaleString(this.locale, { month: 'long' });
     return monthName.charAt(0).toUpperCase() + monthName.slice(1);
@@ -263,6 +264,7 @@ export class GuxCalendar {
 
   getMonthDays(index: number): IDateElement[][] {
     const month = new Date(this.previewValue.getTime());
+    month.setDate(1);
     month.setMonth(month.getMonth() + index);
     const monthIndex = month.getMonth();
     const year = month.getFullYear();


### PR DESCRIPTION
**Description of issue**
When using the range calendar component option users experienced a weird behaviour if they were to select the last few dates of any given month eg ( `29, 30, 31` ). This issue was happening on both keyboard and mouse controls. An example of this issue would be if you were to open the date-picker on the left you have `January` and on the right you have `February`. If a user was to select the `29,30,31` of January this would cause the right side of the calendar to shift to `March` when it should be `February`. 

**RCA**
After doing some investigation the problem lied within the `calendar` component. Within the render function for the calendar it has different functions which do different things the main functions related to this problem were `getMonthDays()`.  If I were to select the 31st of January it will execute the render function twice once for the left side of the calendar and then again for the right side. The problem is that there is not 31 days in February so it would push out the date to March 2nd causing the behaviour described above.

**Solution**
As a solution to this in the **getMonthDays()** I check to see if the date selected is greater than 27. If this is true then I will minus 10 days off the date. This doesn't seem to have an affect on the `value` selected and also doesn't affect the render of the calendar. 

Let me know if you see any issues with this fix or any additions.
