### PR TITLE
feat(aria-live):  aria-live component

### DIFF
--- a/src/components/beta/gux-aria-live/gux-aria-live-priority.types.ts
+++ b/src/components/beta/gux-aria-live/gux-aria-live-priority.types.ts
@@ -1,0 +1,1 @@
+export type GuxAriaLivePriority = 'off' | 'polite' | 'assertive';

--- a/src/components/beta/gux-aria-live/gux-aria-live-role.types.ts
+++ b/src/components/beta/gux-aria-live/gux-aria-live-role.types.ts
@@ -1,0 +1,7 @@
+export type GuxAriaLiveRole =
+  | 'log'
+  | 'status'
+  | 'alert'
+  | 'progressbar'
+  | 'marquee'
+  | 'timer';

--- a/src/components/beta/gux-aria-live/gux-aria-live.tsx
+++ b/src/components/beta/gux-aria-live/gux-aria-live.tsx
@@ -1,0 +1,35 @@
+import { Component, Prop, Element, Host, JSX, h } from '@stencil/core';
+
+import { trackComponent } from '../../../usage-tracking';
+import { GuxAriaLivePriority } from './gux-aria-live-priority.types';
+import { GuxAriaLiveRole } from './gux-aria-live-role.types';
+
+@Component({
+  tag: 'gux-aria-live',
+  shadow: true
+})
+export class GuxAriaLive {
+  /**
+   * Reference the host element.
+   */
+  @Element()
+  root: HTMLElement;
+
+  @Prop()
+  priority: GuxAriaLivePriority;
+
+  @Prop()
+  role: GuxAriaLiveRole;
+
+  componentWillLoad() {
+    trackComponent(this.root);
+  }
+
+  render(): JSX.Element {
+    return (
+      <Host role={this.role} aria-live={this.priority}>
+        <slot />
+      </Host>
+    ) as JSX.Element;
+  }
+}

--- a/src/components/beta/gux-aria-live/readme.md
+++ b/src/components/beta/gux-aria-live/readme.md
@@ -1,0 +1,18 @@
+# gux-aria-live-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute  | Description | Type                                                                    | Default     |
+| ---------- | ---------- | ----------- | ----------------------------------------------------------------------- | ----------- |
+| `priority` | `priority` |             | `"assertive" \| "off" \| "polite"`                                      | `undefined` |
+| `role`     | `role`     |             | `"alert" \| "log" \| "marquee" \| "progressbar" \| "status" \| "timer"` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
**Related task:**
https://inindca.atlassian.net/browse/COMUI-811

**Implementation:**
The `gux-aria-live` contains two properties which are `priority` and `role`. Priority determines the politeness setting of the component which can be one of three values which include `off`, `polite` and `assertive`. The `role` can also be used to determine a live region which can be one of six values including `log`, `status`, `alert`, `progressbar`, `marquee` and `timer`.

The reason for including `role` in this implementation is that there is instances where if you use both `role` and `aria-live` you can maximise compatibility.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#:~:text=Description-,Compatibility%20Notes,-log

The **render** function just contains a simple `Host` wrapper with the necessary attributes and a `slot` for the child content.

**Other**
There is other live region attributes which include `aria-atomic` and `aria-relevant` which I did not include in this implementation as from doing some research it rarely works as intended and may cause confusion.

I have done a bit of testing with the component on the notification toast with different politeness settings and it works great.