### PR TITLE
feat(loading-message) - addition of loading message component

### DIFF
--- a/src/components/beta/gux-loading-message/example.html
+++ b/src/components/beta/gux-loading-message/example.html
@@ -1,0 +1,42 @@
+<h1>gux-loading-message-beta</h1>
+
+<h2>Indeterminate</h2>
+
+<gux-loading-message-beta style="height: 400px; border: 1px dashed gainsboro">
+  <div slot="primary-message">The content is loading...</div>
+  <div slot="additional-guidance">Thank you for waiting.</div>
+  <gux-radial-progress slot="progress"></gux-radial-progress>
+</gux-loading-message-beta>
+
+<h2>Determinate</h2>
+<gux-loading-message-beta style="height: 400px; border: 1px dashed gainsboro">
+  <div slot="primary-message">The content is loading...</div>
+  <div slot="additional-guidance">Thank you for waiting.</div>
+  <gux-radial-progress slot="progress" value="1" max="10"></gux-radial-progress>
+</gux-loading-message-beta>
+
+<h2>Resizing</h2>
+<h4>
+  The loading message will transition from large to medium or small when the
+  view becomes smaller. Use the the drag icon to see the difference.
+</h4>
+<div class="resizing">
+  <gux-loading-message-beta>
+    <div slot="primary-message">The content is loading...</div>
+    <div slot="additional-guidance">Thank you for waiting.</div>
+    <gux-radial-progress
+      slot="progress"
+      value="1"
+      max="10"
+    ></gux-radial-progress>
+  </gux-loading-message-beta>
+</div>
+
+<style>
+  .resizing {
+    width: 250px;
+    overflow: auto;
+    resize: horizontal;
+    border: 1px dashed gainsboro;
+  }
+</style>

--- a/src/components/beta/gux-loading-message/gux-loading-message-constants.ts
+++ b/src/components/beta/gux-loading-message/gux-loading-message-constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Below are the max-widths for the loading component.
+ */
+export const SMALL_LOADING_MESSAGE = 160;
+export const MEDIUM_LOADING_MESSAGE = 300;

--- a/src/components/beta/gux-loading-message/gux-loading-message-size.types.ts
+++ b/src/components/beta/gux-loading-message/gux-loading-message-size.types.ts
@@ -1,0 +1,1 @@
+export type GuxLoadingMessageSizes = 'small' | 'medium' | 'large';

--- a/src/components/beta/gux-loading-message/gux-loading-message.less
+++ b/src/components/beta/gux-loading-message/gux-loading-message.less
@@ -1,0 +1,52 @@
+@import (reference) '../../../style/typography.less';
+@import (reference) '../../../style/spacing.less';
+@import (reference) '../../../style/color-mixins.less';
+
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.gux-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  slot[name='primary-message'] {
+    color: @gux-black-60;
+    text-align: center;
+  }
+
+  slot[name='additional-guidance'] {
+    color: @gux-black-90;
+    text-align: center;
+  }
+
+  &.gux-small,
+  &.gux-medium {
+    padding: @spacing-xs 0 @spacing-2xs;
+
+    slot[name='primary-message'] {
+      .h3();
+    }
+
+    slot[name='additional-guidance'] {
+      .gux-small-text();
+    }
+  }
+
+  &.gux-large {
+    padding: @spacing-medium 0 @spacing-2xs;
+
+    slot[name='primary-message'] {
+      .h1();
+    }
+
+    slot[name='additional-guidance'] {
+      .gux-large-text();
+    }
+  }
+}

--- a/src/components/beta/gux-loading-message/gux-loading-message.tsx
+++ b/src/components/beta/gux-loading-message/gux-loading-message.tsx
@@ -1,0 +1,88 @@
+import { Component, Element, JSX, h, State, readTask } from '@stencil/core';
+import { trackComponent } from '../../../usage-tracking';
+import { GuxLoadingMessageSizes } from './gux-loading-message-size.types';
+import * as loadingMessageWidth from './gux-loading-message-constants';
+
+/**
+ * @slot progress - Required slot for progress.
+ * @slot primary-guidance - Required slot for primary guidance.
+ * @slot additional-guidance - Slot for additional guidance.
+ */
+
+@Component({
+  styleUrl: 'gux-loading-message.less',
+  tag: 'gux-loading-message-beta',
+  shadow: true
+})
+export class GuxLoadingMessage {
+  /**
+   * Reference the host element
+   */
+  @Element()
+  root: HTMLElement;
+
+  @State()
+  hasAdditionalGuidance: boolean;
+
+  @State()
+  loadingMessageSize: GuxLoadingMessageSizes;
+
+  private resizeObserver?: ResizeObserver;
+
+  private updateLoadingMessageSize() {
+    readTask(() => {
+      const containerWidth = this.root.clientWidth;
+
+      if (containerWidth <= loadingMessageWidth.SMALL_LOADING_MESSAGE) {
+        this.loadingMessageSize = 'small';
+      } else if (containerWidth <= loadingMessageWidth.MEDIUM_LOADING_MESSAGE) {
+        this.loadingMessageSize = 'medium';
+      } else {
+        this.loadingMessageSize = 'large';
+      }
+    });
+  }
+
+  componentWillLoad() {
+    trackComponent(this.root);
+  }
+
+  componentDidLoad() {
+    if (!this.resizeObserver && window.ResizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => {
+        this.updateLoadingMessageSize();
+      });
+    }
+
+    if (this.resizeObserver) {
+      this.resizeObserver.observe(this.root);
+    }
+
+    setTimeout(() => {
+      this.updateLoadingMessageSize();
+    }, 500);
+  }
+
+  disconnectedCallback() {
+    if (this.resizeObserver) {
+      this.resizeObserver.unobserve(this.root);
+    }
+  }
+
+  render(): JSX.Element {
+    return (
+      <div
+        class={{
+          'gux-container': true,
+          [`gux-${this.loadingMessageSize}`]: true
+        }}
+        role="alert"
+        aria-live="assertive"
+      >
+        <slot name="progress"></slot>
+        <slot name="primary-message"></slot>
+        <slot name="additional-guidance"></slot>
+      </div>
+    ) as JSX.Element;
+  }
+}

--- a/src/components/beta/gux-loading-message/readme.md
+++ b/src/components/beta/gux-loading-message/readme.md
@@ -1,0 +1,19 @@
+# gux-loading-message-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Slots
+
+| Slot                    | Description                         |
+| ----------------------- | ----------------------------------- |
+| `"additional-guidance"` | Slot for additional guidance.       |
+| `"primary-guidance"`    | Required slot for primary guidance. |
+| `"progress"`            | Required slot for progress.         |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/beta/gux-loading-message/tests/__snapshots__/gux-loading-message.e2e.ts.snap
+++ b/src/components/beta/gux-loading-message/tests/__snapshots__/gux-loading-message.e2e.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-loading-message-beta renders 1`] = `" <span slot=\\"primary-message\\">The content is loading...</span> <span slot=\\"additional-guidance\\">Thank you for waiting.</span> <gux-radial-progress slot=\\"progress\\" hydrated=\\"\\"></gux-radial-progress>"`;

--- a/src/components/beta/gux-loading-message/tests/__snapshots__/gux-loading-message.spec.ts.snap
+++ b/src/components/beta/gux-loading-message/tests/__snapshots__/gux-loading-message.spec.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-loading-message-beta #render should render the component as expected 1`] = `
+<gux-loading-message-beta>
+  <mock:shadow-root>
+    <div aria-live="assertive" class="gux-container gux-undefined" role="alert">
+      <slot name="progress"></slot>
+      <slot name="primary-message"></slot>
+      <slot name="additional-guidance"></slot>
+    </div>
+  </mock:shadow-root>
+  <span slot="primary-message">
+    The content is loading...
+  </span>
+  <span slot="additional-guidance">
+    Thank you for waiting.
+  </span>
+  <gux-radial-progress slot="progress"></gux-radial-progress>
+</gux-loading-message-beta>
+`;

--- a/src/components/beta/gux-loading-message/tests/gux-loading-message.e2e.ts
+++ b/src/components/beta/gux-loading-message/tests/gux-loading-message.e2e.ts
@@ -1,0 +1,15 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('gux-loading-message-beta', () => {
+  it('renders', async () => {
+    const html = `<gux-loading-message-beta>
+        <span slot="primary-message">The content is loading...</span>
+        <span slot="additional-guidance">Thank you for waiting.</span>
+        <gux-radial-progress slot="progress" />
+        </gux-loading-message-beta>`;
+    const page = await newE2EPage({ html });
+    const element = await page.find('gux-loading-message-beta');
+
+    expect(element.innerHTML).toMatchSnapshot();
+  });
+});

--- a/src/components/beta/gux-loading-message/tests/gux-loading-message.spec.ts
+++ b/src/components/beta/gux-loading-message/tests/gux-loading-message.spec.ts
@@ -1,0 +1,32 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GuxLoadingMessage } from '../gux-loading-message';
+
+const components = [GuxLoadingMessage];
+const language = 'en';
+
+describe('gux-loading-message-beta', () => {
+  it('should build', async () => {
+    const html = `<gux-loading-message-beta>
+        <span slot="primary-message">The content is loading...</span>
+        <span slot="additional-guidance">Thank you for waiting.</span>
+        <gux-radial-progress slot="progress" />
+        </gux-loading-message-beta>`;
+    const page = await newSpecPage({ components, language, html });
+    const component = page.rootInstance;
+
+    expect(component).toBeInstanceOf(GuxLoadingMessage);
+  });
+
+  describe('#render', () => {
+    it(`should render the component as expected`, async () => {
+      const html = `<gux-loading-message-beta>
+            <span slot="primary-message">The content is loading...</span>
+            <span slot="additional-guidance">Thank you for waiting.</span>
+            <gux-radial-progress slot="progress" />
+            </gux-loading-message-beta>`;
+      const page = await newSpecPage({ components, language, html });
+
+      expect(page.root).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
**Related Story :** 
https://inindca.atlassian.net/browse/COMUI-1096

**Description of task :**
Creation of loading state component.

**Things to note:**

- The body slot is optional.

**Items still to be considered:**

- Name of component.
- Should we include a default option if nothing slotted is supplied ie `<gux-loading-message size="medium" />` and this would contain a default title and possibly a body aswell (use messaging supplied in anatomy).
- From an accessibility standpoint I was thinking the use of `aria-live` might work well here so I have included it in this iteration.
- With the `gux-radial-progress` it requires screen-reader text attribute but would this be redundant in this component as there is a title and body? Potentially add an `aria-hidden` tag.