### PR TITLE
feat(css): add gux-prefixed spacing variables

### DIFF
--- a/src/style/css-custom-properties.less
+++ b/src/style/css-custom-properties.less
@@ -97,6 +97,19 @@
   --gux-warm-red: @gux-warm-red;
 
   // Spacing
+  --gux-soft-grid-increment: @gux-soft-grid-increment;
+  --gux-spacing-3xs: @gux-spacing-3xs;
+  --gux-spacing-2xs: @gux-spacing-2xs;
+  --gux-spacing-xs: @gux-spacing-xs;
+  --gux-spacing-small: @gux-spacing-small;
+  --gux-spacing-medium: @gux-spacing-medium;
+  --gux-spacing-large: @gux-spacing-large;
+  --gux-spacing-xl: @gux-spacing-xl;
+  --gux-spacing-2xl: @gux-spacing-2xl;
+  --gux-spacing-3xl: @gux-spacing-3xl;
+  --gux-spacing-4xl: @gux-spacing-4xl;
+
+  // DEPRECATED unprefixed spacing variables will be removed in a future release
   --soft-grid-increment: @soft-grid-increment;
   --spacing-3xs: @spacing-3xs;
   --spacing-2xs: @spacing-2xs;

--- a/src/style/spacing.less
+++ b/src/style/spacing.less
@@ -1,12 +1,26 @@
-@soft-grid-increment: 2px;
+@gux-soft-grid-increment: 2px;
 
-@spacing-3xs: (@soft-grid-increment * 1);
-@spacing-2xs: (@soft-grid-increment * 2);
-@spacing-xs: (@soft-grid-increment * 4);
-@spacing-small: (@soft-grid-increment * 6);
-@spacing-medium: (@soft-grid-increment * 8);
-@spacing-large: (@soft-grid-increment * 12);
-@spacing-xl: (@soft-grid-increment * 16);
-@spacing-2xl: (@soft-grid-increment * 20);
-@spacing-3xl: (@soft-grid-increment * 24);
-@spacing-4xl: (@soft-grid-increment * 32);
+@gux-spacing-3xs: (@gux-soft-grid-increment * 1);
+@gux-spacing-2xs: (@gux-soft-grid-increment * 2);
+@gux-spacing-xs: (@gux-soft-grid-increment * 4);
+@gux-spacing-small: (@gux-soft-grid-increment * 6);
+@gux-spacing-medium: (@gux-soft-grid-increment * 8);
+@gux-spacing-large: (@gux-soft-grid-increment * 12);
+@gux-spacing-xl: (@gux-soft-grid-increment * 16);
+@gux-spacing-2xl: (@gux-soft-grid-increment * 20);
+@gux-spacing-3xl: (@gux-soft-grid-increment * 24);
+@gux-spacing-4xl: (@gux-soft-grid-increment * 32);
+
+// The following unprefixed names are deprecated and will be removed in a future release
+@soft-grid-increment: @gux-soft-grid-increment;
+
+@spacing-3xs: @gux-spacing-3xs;
+@spacing-2xs: @gux-spacing-2xs;
+@spacing-xs: @gux-spacing-xs;
+@spacing-small: @gux-spacing-small;
+@spacing-medium: @gux-spacing-medium;
+@spacing-large: @gux-spacing-large;
+@spacing-xl: @gux-spacing-xl;
+@spacing-2xl: @gux-spacing-2xl;
+@spacing-3xl: @gux-spacing-3xl;
+@spacing-4xl: @gux-spacing-4xl;


### PR DESCRIPTION
Adds gux-prefixed spacing variables. Existing usages of the unprefixed names are not updated, but I am happy to do that as well.