### PR TITLE
docs(links): open external links in new tab

### DIFF
--- a/docs/src/component-listing/app.js
+++ b/docs/src/component-listing/app.js
@@ -38,9 +38,9 @@ export function bootstrap() {
                   .join('')}
                   <div class="sticky-footer">
                   <h2>Resources</h2>
-                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-webcomponents/tree/main/docs/migrations/v3">V2 -> V3 Migration Guide</a>
-                    <a class="resources-link" href="https://spark.genesys.com">Spark UX Documentation</a>
-                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-webcomponents/blob/main/README.md#genesys-web-components">Web Components README</a>
+                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-webcomponents/tree/main/docs/migrations/v3" target="_blank">V2 -> V3 Migration Guide</a>
+                    <a class="resources-link" href="https://spark.genesys.com" target="_blank">Spark UX Documentation</a>
+                    <a class="resources-link" href="https://github.com/MyPureCloud/genesys-webcomponents/blob/main/README.md#genesys-web-components" target="_blank">Web Components README</a>
                   </div>
             </nav>
             <iframe id="componentFrame" title="Component Examples"/>


### PR DESCRIPTION
COMUI-1119

Links were not opening when docs site was accessed through `common-ui-docs` as an iframed app

This is related to PR in `common-ui-docs` repo https://bitbucket.org/inindca/common-ui-docs/pull-requests/3/comui-1119-update-iframe-coordinator. The version of `iframe-coordinator` being used by `common-ui-docs` was updated to allow popups.

