### PR TITLE
feat(blank-state) - addition of blank-state component

### DIFF
--- a/src/components/beta/gux-blank-state/example.html
+++ b/src/components/beta/gux-blank-state/example.html
@@ -1,0 +1,25 @@
+<h1>gux-blank-state-beta</h1>
+
+<h4>
+  The blank state will transition from large to medium or small when the view
+  becomes smaller. Use the the drag icon to see the difference.
+</h4>
+
+<gux-blank-state-beta class="blank-state-styling">
+  <gux-icon slot="image" icon-name="robot-circle" decorative="true"></gux-icon>
+  <div slot="primary-message">Sorry, something went wrong.</div>
+  <div slot="additional-guidance">Please refresh this page to try again.</div>
+  <button slot="call-to-action" type="button" onclick="notify(event)">
+    Call to action
+  </button>
+</gux-blank-state-beta>
+
+<style>
+  .blank-state-styling {
+    width: 250px;
+    height: 250px;
+    overflow: auto;
+    resize: horizontal;
+    border: 1px dashed gainsboro;
+  }
+</style>

--- a/src/components/beta/gux-blank-state/gux-blank-state-constants.ts
+++ b/src/components/beta/gux-blank-state/gux-blank-state-constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Below are the max-widths for the blank state component.
+ */
+export const SMALL_STATE = 160;
+export const MEDIUM_STATE = 300;

--- a/src/components/beta/gux-blank-state/gux-blank-state.less
+++ b/src/components/beta/gux-blank-state/gux-blank-state.less
@@ -1,0 +1,64 @@
+@import (reference) '../../../style/typography.less';
+@import (reference) '../../../style/spacing.less';
+@import (reference) '../../../style/color-mixins.less';
+
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.gux-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  ::slotted(gux-icon) {
+    width: 48px;
+    height: 48px;
+    color: @gux-grey-40;
+  }
+
+  slot[name='primary-message'] {
+    color: @gux-black-60;
+    text-align: center;
+    .h3();
+  }
+
+  slot[name='additional-guidance'] {
+    color: @gux-black-60;
+    text-align: center;
+    .gux-small-text();
+  }
+
+  &.gux-small,
+  &.gux-medium {
+    .gux-message-container {
+      padding: @spacing-xs 0 @spacing-2xs;
+    }
+
+    .gux-guidance-container {
+      padding-bottom: @spacing-xs;
+    }
+  }
+
+  &.gux-large {
+    .gux-message-container {
+      padding: @spacing-medium 0 @spacing-2xs;
+
+      slot[name='primary-message'] {
+        .h1();
+      }
+    }
+
+    .gux-guidance-container {
+      padding-bottom: @spacing-medium;
+
+      slot[name='additional-guidance'] {
+        .gux-large-text();
+      }
+    }
+  }
+}

--- a/src/components/beta/gux-blank-state/gux-blank-state.tsx
+++ b/src/components/beta/gux-blank-state/gux-blank-state.tsx
@@ -1,0 +1,77 @@
+import { Component, Element, JSX, h, State, readTask } from '@stencil/core';
+import { trackComponent } from '../../../usage-tracking';
+import { GuxBlankStateSizes } from './gux-blank-state.types';
+import { OnResize } from '../../../utils/decorator/on-resize';
+import * as blankStateWidth from './gux-blank-state-constants';
+
+/**
+ * @slot primary-message - Required slot for primary-message.
+ * @slot image - Slot for gux-icon element.
+ * @slot additional-guidance - Slot for additional-guidance.
+ * @slot call-to-action - Slot for the message call to action button.
+ */
+
+@Component({
+  styleUrl: 'gux-blank-state.less',
+  tag: 'gux-blank-state-beta',
+  shadow: true
+})
+export class GuxBlankState {
+  /**
+   * Reference the host element
+   */
+  @Element()
+  root: HTMLElement;
+
+  @State()
+  blankStateSize: GuxBlankStateSizes;
+
+  @OnResize()
+  onResize(): void {
+    this.setBlankStateSize();
+  }
+
+  componentWillLoad() {
+    trackComponent(this.root);
+  }
+
+  componentDidLoad() {
+    this.setBlankStateSize();
+  }
+
+  private setBlankStateSize(): void {
+    readTask(() => {
+      const containerWidth = this.root.clientWidth;
+
+      if (containerWidth <= blankStateWidth.SMALL_STATE) {
+        this.blankStateSize = 'small';
+      } else if (containerWidth <= blankStateWidth.MEDIUM_STATE) {
+        this.blankStateSize = 'medium';
+      } else {
+        this.blankStateSize = 'large';
+      }
+    });
+  }
+
+  render(): JSX.Element {
+    return (
+      <div
+        class={{
+          'gux-container': true,
+          [`gux-${this.blankStateSize}`]: true
+        }}
+      >
+        <slot name="image"></slot>
+        <div class="gux-message-container">
+          <slot name="primary-message"></slot>
+        </div>
+        <div class="gux-guidance-container">
+          <slot name="additional-guidance"></slot>
+        </div>
+        <gux-button-slot-beta accent="primary">
+          <slot name="call-to-action"></slot>
+        </gux-button-slot-beta>
+      </div>
+    ) as JSX.Element;
+  }
+}

--- a/src/components/beta/gux-blank-state/gux-blank-state.types.ts
+++ b/src/components/beta/gux-blank-state/gux-blank-state.types.ts
@@ -1,0 +1,1 @@
+export type GuxBlankStateSizes = 'small' | 'medium' | 'large';

--- a/src/components/beta/gux-blank-state/readme.md
+++ b/src/components/beta/gux-blank-state/readme.md
@@ -1,0 +1,33 @@
+# gux-message-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Slots
+
+| Slot                    | Description                                 |
+| ----------------------- | ------------------------------------------- |
+| `"additional-guidance"` | Slot for additional-guidance.               |
+| `"call-to-action"`      | Slot for the message call to action button. |
+| `"image"`               | Slot for gux-icon element.                  |
+| `"primary-message"`     | Required slot for primary-message.          |
+
+
+## Dependencies
+
+### Depends on
+
+- [gux-button-slot-beta](../gux-button-slot)
+
+### Graph
+```mermaid
+graph TD;
+  gux-blank-state-beta --> gux-button-slot-beta
+  style gux-blank-state-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/beta/gux-blank-state/tests/__snapshots__/gux-blank-state.spec.ts.snap
+++ b/src/components/beta/gux-blank-state/tests/__snapshots__/gux-blank-state.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-blank-state-beta #render should render the component as expected 1`] = `
+<gux-blank-state-beta>
+  <mock:shadow-root>
+    <div class="gux-container gux-large">
+      <slot name="image"></slot>
+      <div class="gux-message-container">
+        <slot name="primary-message"></slot>
+      </div>
+      <div class="gux-guidance-container">
+        <slot name="additional-guidance"></slot>
+      </div>
+      <gux-button-slot-beta accent="primary">
+        <slot name="call-to-action"></slot>
+      </gux-button-slot-beta>
+    </div>
+  </mock:shadow-root>
+  <gux-icon decorative="true" icon-name="robot-circle" slot="image"></gux-icon>
+  <div slot="primary-message">
+    Sorry, something went wrong.
+  </div>
+  <div slot="additional-guidance">
+    Please refresh this page to try again.
+  </div>
+  <button onclick="notify(event)" slot="call-to-action" type="button">
+    Call to action
+  </button>
+</gux-blank-state-beta>
+`;

--- a/src/components/beta/gux-blank-state/tests/gux-blank-state.e2e.ts
+++ b/src/components/beta/gux-blank-state/tests/gux-blank-state.e2e.ts
@@ -1,0 +1,30 @@
+import { E2EElement, E2EPage } from '@stencil/core/testing';
+import { a11yCheck, newSparkE2EPage } from '../../../../../tests/e2eTestUtils';
+
+describe('gux-blank-state-beta', () => {
+  let page: E2EPage;
+  let element: E2EElement;
+
+  const html = `
+  <gux-blank-state-beta lang="en">
+  <gux-icon slot="image" icon-name="robot-circle" decorative="true"></gux-icon>
+  <div slot="primary-message">Sorry, something went wrong.</div>
+  <div slot="additional-guidance">Please refresh this page to try again.</div>
+  <button slot="call-to-action" type="button" onclick="notify(event)">
+    Call to action
+  </button>
+  </gux-blank-state-beta>
+`;
+
+  beforeAll(async () => {
+    page = await newSparkE2EPage({ html });
+  });
+
+  it('renders', async () => {
+    element = await page.find('gux-blank-state-beta');
+
+    await a11yCheck(page);
+
+    expect(element).toHaveAttribute('hydrated');
+  });
+});

--- a/src/components/beta/gux-blank-state/tests/gux-blank-state.spec.ts
+++ b/src/components/beta/gux-blank-state/tests/gux-blank-state.spec.ts
@@ -1,0 +1,47 @@
+jest.mock('../../../../utils/decorator/on-resize', () => ({
+  __esModule: true,
+  OnResize: jest.fn()
+}));
+
+import MutationObserver from 'mutation-observer';
+import { newSpecPage } from '@stencil/core/testing';
+import { GuxBlankState } from '../gux-blank-state';
+
+const components = [GuxBlankState];
+const language = 'en';
+
+beforeEach(async () => {
+  global.MutationObserver = MutationObserver;
+});
+
+describe('gux-blank-state-beta', () => {
+  it('should build', async () => {
+    const html = `
+        <gux-blank-state-beta>
+        <gux-icon slot="image" icon-name="robot-circle" decorative="true"></gux-icon>
+        <div slot="primary-message">Sorry, something went wrong.</div>
+        <div slot="additional-guidance">Please refresh this page to try again.</div>
+        <button slot="call-to-action" type="button" onclick="notify(event)">Call to action</button>
+      </gux-blank-state-beta>`;
+
+    const page = await newSpecPage({ components, language, html });
+    const component = page.rootInstance;
+
+    expect(component).toBeInstanceOf(GuxBlankState);
+  });
+
+  describe('#render', () => {
+    it(`should render the component as expected`, async () => {
+      const html = `
+        <gux-blank-state-beta>
+        <gux-icon slot="image" icon-name="robot-circle" decorative="true"></gux-icon>
+        <div slot="primary-message">Sorry, something went wrong.</div>
+        <div slot="additional-guidance">Please refresh this page to try again.</div>
+        <button slot="call-to-action" type="button" onclick="notify(event)">Call to action</button>
+      </gux-blank-state-beta>`;
+      const page = await newSpecPage({ components, language, html });
+
+      expect(page.root).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/beta/gux-button-slot/gux-button-slot.tsx
+++ b/src/components/beta/gux-button-slot/gux-button-slot.tsx
@@ -19,8 +19,15 @@ export class GuxButtonSlot {
   accent: GuxButtonAccent = 'secondary';
 
   private validateSlotContent(): void {
-    const slottedElement = this.root.children[0];
-    const slottedTagName = slottedElement.tagName;
+    let slottedElement = this.root.children[0];
+    let slottedTagName = slottedElement.tagName;
+
+    if (slottedTagName === 'SLOT') {
+      slottedElement = (
+        slottedElement as HTMLSlotElement
+      ).assignedNodes()[0] as HTMLElement;
+      slottedTagName = slottedElement.tagName;
+    }
 
     if (slottedTagName === 'BUTTON') {
       return;

--- a/src/components/beta/gux-button-slot/readme.md
+++ b/src/components/beta/gux-button-slot/readme.md
@@ -22,6 +22,7 @@
 
  - [gux-action-button](../../stable/gux-action-button)
  - [gux-action-button-legacy](../../legacy/gux-action-button-legacy)
+ - [gux-blank-state-beta](../gux-blank-state)
  - [gux-button-multi](../../stable/gux-button-multi)
  - [gux-button-multi-legacy](../../legacy/gux-button-multi-legacy)
  - [gux-pagination-buttons](../../stable/gux-pagination/gux-pagination-buttons)
@@ -34,6 +35,7 @@
 graph TD;
   gux-action-button --> gux-button-slot-beta
   gux-action-button-legacy --> gux-button-slot-beta
+  gux-blank-state-beta --> gux-button-slot-beta
   gux-button-multi --> gux-button-slot-beta
   gux-button-multi-legacy --> gux-button-slot-beta
   gux-pagination-buttons --> gux-button-slot-beta


### PR DESCRIPTION
**Description**
Create message component , relates to task https://inindca.atlassian.net/browse/COMUI-1074.

Open to changing the name of the component if there is a more suitable name.

**Summary :**

- There is no illustrations in this current implementation just the use of icons.
- Should we have default message like the example in figma.
- For accessibility I was thinking aria-live might be a good fit with the polite setting.
