### PR TITLE
(fix) - Tooltip appears for button when focus not on button, Does not get dismissed by clicking outside

### DIFF
--- a/src/components/stable/gux-tooltip/gux-tooltip.less
+++ b/src/components/stable/gux-tooltip/gux-tooltip.less
@@ -16,10 +16,21 @@
   .gux-shadow-20();
 
   opacity: 0;
-  transition: opacity 0.25s ease-in-out;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 :host(.gux-show) {
   visibility: visible !important;
-  opacity: 1;
+  animation-name: fade-in;
+  animation-duration: 250ms;
+  animation-delay: 1s;
+  animation-fill-mode: forwards;
 }

--- a/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -24,10 +24,9 @@ import { GuxTooltipPlacements } from './gux-tooltip.types';
   shadow: true
 })
 export class GuxTooltip {
-  private delayTimeout: NodeJS.Timer;
   private forElement: HTMLElement;
-  private mouseenterHandler: () => void = () => this.show();
-  private mouseleaveHandler: () => void = () => this.hide();
+  private pointerenterHandler: () => void = () => this.show();
+  private pointerleaveHandler: () => void = () => this.hide();
   private focusinHandler: () => void = () => this.show();
   private focusoutHandler: () => void = () => this.hide();
   private popperInstance: Instance;
@@ -81,13 +80,10 @@ export class GuxTooltip {
 
   private show(): void {
     this.popperInstance.forceUpdate();
-    this.delayTimeout = setTimeout(() => {
-      this.isShown = true;
-    }, 750); // the css transition is 250ms
+    this.isShown = true;
   }
 
   private hide(): void {
-    clearTimeout(this.delayTimeout);
     this.isShown = false;
   }
 
@@ -124,8 +120,14 @@ export class GuxTooltip {
         strategy: 'fixed'
       });
 
-      this.forElement.addEventListener('mouseenter', this.mouseenterHandler);
-      this.forElement.addEventListener('mouseleave', this.mouseleaveHandler);
+      this.forElement.addEventListener(
+        'pointerenter',
+        this.pointerenterHandler
+      );
+      this.forElement.addEventListener(
+        'pointerleave',
+        this.pointerleaveHandler
+      );
       this.forElement.addEventListener('focusin', this.focusinHandler);
       this.forElement.addEventListener('focusout', this.focusoutHandler);
     } else {
@@ -145,8 +147,14 @@ export class GuxTooltip {
       this.popperInstance = null;
     }
 
-    this.forElement.removeEventListener('mouseenter', this.mouseenterHandler);
-    this.forElement.removeEventListener('mouseleave', this.mouseleaveHandler);
+    this.forElement.removeEventListener(
+      'pointerenter',
+      this.pointerenterHandler
+    );
+    this.forElement.removeEventListener(
+      'pointerleave',
+      this.pointerleaveHandler
+    );
     this.forElement.removeEventListener('focusin', this.focusinHandler);
     this.forElement.removeEventListener('focusout', this.focusoutHandler);
   }


### PR DESCRIPTION
Ticket : https://inindca.atlassian.net/browse/COMUI-1103

**Description :** 
When gux-tooltip is added to a gux-button, when we click on that button and either

The button gets programmatically disabled , or,

we follow up with a click outside the button.

we get an issue that the tooltip still appears for that button, and cannot be dismissed by clicking anywhere outside the button. The tooltip can only be disabled by hovering over that button again.

**Res:**
I removed the setTimeout/clearTimeout for the css transition as I dont think it is needed. Instead I updated the transition property to 1s in the css to align with the spark design. I also added a disabled check to the **mouseenter** as when the button or element is disabled on hover it will still display the tooltip. I just check to see if that element has an attribute of disabled if so the tooltip will not be displayed.