### PR TITLE
style(checkbox): align error message to label instead of input

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.less
@@ -33,10 +33,20 @@
   }
 }
 
-.gux-input {
-  position: relative;
-  height: @gux-icon-size-default-global + (2 * @spacing-2xs);
-  line-height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+.gux-input-label {
+  display: flex;
+  flex-direction: row;
+
+  .gux-input {
+    position: relative;
+    height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+    line-height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+  }
+
+  .gux-label {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 ::slotted(input[type='checkbox']) {

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
@@ -59,13 +59,17 @@ export class GuxFormFieldCheckbox {
         }}
       >
         <div class="gux-form-field-container">
-          <div class="gux-input">
-            <slot name="input" onSlotchange={() => this.setInput()} />
-            <slot name="label" />
+          <div class="gux-input-label">
+            <div class="gux-input">
+              <slot name="input" onSlotchange={() => this.setInput()} />
+            </div>
+            <div class="gux-label">
+              <slot name="label" />
+              <GuxFormFieldError hasError={this.hasError}>
+                <slot name="error" />
+              </GuxFormFieldError>
+            </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
-            <slot name="error" />
-          </GuxFormFieldError>
         </div>
       </Host>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
@@ -4,14 +4,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
 
 exports[`gux-form-field-checkbox #render should render component as expected (1) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -21,14 +25,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
 
 exports[`gux-form-field-checkbox #render should render component as expected (2) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -38,14 +46,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
 
 exports[`gux-form-field-checkbox #render should render component as expected (3) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error gux-show">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error gux-show">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -55,14 +67,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
 
 exports[`gux-form-field-checkbox #render should render component as expected (4) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -72,14 +88,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
 
 exports[`gux-form-field-checkbox #render should render component as expected (5) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error gux-show">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error gux-show">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -4,14 +4,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
 <gux-form-field-checkbox>
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -27,14 +31,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
 <gux-form-field-checkbox class="gux-disabled">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -50,14 +58,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
 <gux-form-field-checkbox class="gux-input-error">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error gux-show">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error gux-show">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -76,14 +88,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
 <gux-form-field-checkbox>
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -99,14 +115,18 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
 <gux-form-field-checkbox class="gux-input-error">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error gux-show">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error gux-show">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Related ticket: https://inindca.atlassian.net/browse/COMUI-1166

I am not sure if this change will need to go through the design team but I think it should be added. I currently just added the styling to the `form-field-checkbox` component but this will also need to be applied to the `form-field-radio` component.

**Description**
"When you have multiple checkboxes or radios stacked and one is using the error slot, it becomes visually confusing what's what. It would be clearer that the error belongs to the checkbox or radio above by aligning to its label rather than its input."