### PR TITLE
fix(list): addition of styling for when false value is assigned to di…

### DIFF
--- a/src/components/stable/gux-list/gux-list-item/gux-list-item.less
+++ b/src/components/stable/gux-list/gux-list-item/gux-list-item.less
@@ -10,6 +10,10 @@
   pointer-events: none;
 }
 
+:host([disabled='false']) {
+  pointer-events: auto;
+}
+
 ::slotted(gux-icon) {
   width: 16px;
   height: 16px;

--- a/src/components/stable/gux-list/gux-list-item/gux-list-item.tsx
+++ b/src/components/stable/gux-list/gux-list-item/gux-list-item.tsx
@@ -11,7 +11,7 @@ import { getClosestElement } from '../../../../utils/dom/get-closest-element';
 })
 export class GuxListItem {
   @Element()
-  root: HTMLElement;
+  root: HTMLGuxListItemElement;
 
   @Prop()
   disabled: boolean = false;


### PR DESCRIPTION
**Related Task :** https://inindca.atlassian.net/browse/COMUI-1170

**Description :** 
From the HTML spec: "The values "true" and "false" are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether."

[HTML Standard](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) 

However in this component setting the attribute to true or false displays different behaviour. True has the correct behaviour in that is both fades the item and removes interactivity. False also removes interactivity but the item remains unfaded giving the user the impression it isn’t disabled.

**Resolution:**
Apply faded css styling if a value of `false` is applied to the `disabled` attribute.