### PR TITLE
feat(css): overridable z-index variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,24 @@ The library requires the inclusion of a baseline set of CSS styles that it provi
 - Classes for specific typography patterns
 - CSS variables for colors
 - CSS variables for spacing
+- CSS variables for z-index of "floating" non-flow content like menus, tooltips, popovers, or modals
 
 The best mechanism for importing the stylesheet into your project will depend on how you handle CSS in your project in general. Reach out to the Common UI Development group if you're having trouble with your specific integration.
 
 **Note: Since v3 this baseline stylesheet is required.**
+
+#### Contextual z-index overrides
+
+In complex layouts you may find that your app's use of `z-index` conflicts with the default `z-index` applied to raised content like dropdown menus, tooltips, popovers, or modals.
+
+Components with layered content elements like menus or popovers use CSS variables for their `z-index`, and you can override the default z-index in your app's stylesheet for the specific context where you have a conflict.
+
+```css
+.myApp .someElementThatHasContentWithCustomZIndexes {
+  /* Provide higher z-index for dropdowns in this part of my app so they appear above the surrounding content */
+  --gux-zindex-popup: 100;
+}
+```
 
 ### Genesys Cloud applications
 

--- a/src/components/beta/gux-flyout-menu/gux-flyout-menu.less
+++ b/src/components/beta/gux-flyout-menu/gux-flyout-menu.less
@@ -1,12 +1,13 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/mixins.less';
 @import (reference) '../../../style/shadows.less';
+@import (reference) '../../../style/zindex.less';
 
 @gux-arrow-height: 5px;
 
 // Style
 :host {
-  z-index: 2;
+  z-index: var(--gux-zindex-popover, @gux-zindex-popover);
   color: @gux-type;
   cursor: default;
 }

--- a/src/components/beta/gux-popover-list/gux-popover-list.less
+++ b/src/components/beta/gux-popover-list/gux-popover-list.less
@@ -1,6 +1,7 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/shadows.less';
 @import (reference) '../../../style/spacing.less';
+@import (reference) '../../../style/zindex.less';
 
 @gux-arrow-height: 5px;
 
@@ -9,7 +10,7 @@
 }
 
 .gux-popover-wrapper {
-  z-index: 2;
+  z-index: var(--gux-zindex-popover, @gux-zindex-popover);
   display: inline-block;
   padding: @spacing-xs 0;
   background-color: @gux-grey-100;

--- a/src/components/beta/gux-table/gux-table-select-menu/gux-table-select-popover/gux-table-select-popover.less
+++ b/src/components/beta/gux-table/gux-table-select-menu/gux-table-select-popover/gux-table-select-popover.less
@@ -1,13 +1,14 @@
 @import (reference) '../../../../../style/color.less';
 @import (reference) '../../../../../style/shadows.less';
 @import (reference) '../../../../../style/spacing.less';
+@import (reference) '../../../../../style/zindex.less';
 
 :host {
   color: @gux-black-50;
 }
 
 .gux-popover-wrapper {
-  z-index: 2;
+  z-index: var(--gux-zindex-popover, @gux-zindex-popover);
   display: inline-block;
   padding: @spacing-xs 0;
   background-color: @gux-grey-100;

--- a/src/components/legacy/gux-dropdown-legacy/gux-dropdown.less
+++ b/src/components/legacy/gux-dropdown-legacy/gux-dropdown.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/shadows.less';
 @import (reference) '../../../style/mixins.less';
+@import (reference) '../../../style/zindex.less';
 
 // Style
 
@@ -100,7 +101,7 @@ gux-dropdown-legacy {
 
     .gux-options {
       position: absolute;
-      z-index: 1;
+      z-index: var(--gux-zindex-popup, @gux-zindex-popup);
       display: none;
       width: 100%;
       padding: 8px 0;

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-color/gux-input-color.less
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-color/gux-input-color.less
@@ -1,5 +1,6 @@
 @import (reference) '../../../../../style/color.less';
 @import (reference) '../../../../../style/typography.less';
+@import (reference) '../../../../../style/zindex.less';
 
 gux-input-color {
   color: @gux-black-50;
@@ -68,7 +69,7 @@ gux-input-color {
     position: absolute;
     top: 100%;
     left: 0;
-    z-index: 1;
+    z-index: var(--gux-zindex-popup, @gux-zindex-popup);
     display: none;
     width: 100%;
 

--- a/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
+++ b/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../style/mixins.less';
 @import (reference) '../../../style/shadows.less';
 @import (reference) '../../../style/typography.less';
+@import (reference) '../../../style/zindex.less';
 
 @background-color: @gux-grey-90;
 @border-color: @gux-border;
@@ -101,7 +102,7 @@ div.gux-dropdown {
   .gux-advanced-dropdown-menu {
     position: absolute;
     top: 36px;
-    z-index: 1;
+    z-index: var(--gux-zindex-popup, @gux-zindex-popup);
     display: none;
     width: 100%;
     background: @gux-background;

--- a/src/components/stable/gux-datepicker/gux-datepicker.less
+++ b/src/components/stable/gux-datepicker/gux-datepicker.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../style/spacing.less';
 @import (reference) '../../../style/typography.less';
 @import (reference) '../../../style/mixins.less';
+@import (reference) '../../../style/zindex.less';
 
 :host {
   display: block;
@@ -117,7 +118,7 @@
       }
 
       gux-calendar {
-        z-index: 1;
+        z-index: var(--gux-zindex-popup, @gux-zindex-popup);
         display: none;
       }
     }

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.less
@@ -4,6 +4,7 @@
 // @import (reference) '../../../../../style/spacing.less';
 // @import (reference) '../../../../../style/typography.less';
 // @import (reference) '../../../../../style/variables.less';
+@import (reference) '../../../../../style/zindex.less';
 @import (reference)
   '../../functional-components/gux-form-field-container/gux-form-field-container.less';
 @import (reference)
@@ -131,7 +132,7 @@
       .gux-small-text();
 
       position: absolute;
-      z-index: 1;
+      z-index: var(--gux-zindex-tooltip, @gux-zindex-tooltip);
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/components/stable/gux-modal/gux-modal.less
+++ b/src/components/stable/gux-modal/gux-modal.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/spacing.less';
 @import (reference) '../../../style/shadows.less';
+@import (reference) '../../../style/zindex.less';
 
 // Style
 :host {
@@ -11,7 +12,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 1;
+    z-index: var(--gux-zindex-modal, @gux-zindex-modal);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/stable/gux-popover/gux-popover.less
+++ b/src/components/stable/gux-popover/gux-popover.less
@@ -1,6 +1,7 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/shadows.less';
 @import (reference) '../../../style/spacing.less';
+@import (reference) '../../../style/zindex.less';
 
 @gux-arrow-height: 5px;
 
@@ -9,7 +10,7 @@
 }
 
 .gux-popover-wrapper {
-  z-index: 2;
+  z-index: var(--gux-zindex-popover, @gux-zindex-popover);
   display: inline-block;
   padding: @spacing-medium;
   background-color: @gux-grey-100;

--- a/src/components/stable/gux-popup/gux-popup.less
+++ b/src/components/stable/gux-popup/gux-popup.less
@@ -1,4 +1,5 @@
 @import (reference) '../../../style/color.less';
+@import (reference) '../../../style/zindex.less';
 
 .gux-target-container {
   &.gux-disabled {
@@ -9,7 +10,7 @@
 }
 
 .gux-popup-container {
-  z-index: 1;
+  z-index: var(--gux-zindex-popup, @gux-zindex-popup);
   visibility: hidden;
 
   &.gux-expanded {

--- a/src/components/stable/gux-tooltip/gux-tooltip.less
+++ b/src/components/stable/gux-tooltip/gux-tooltip.less
@@ -1,8 +1,9 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/shadows.less';
+@import (reference) '../../../style/zindex.less';
 
 :host {
-  z-index: 1;
+  z-index: var(--gux-zindex-tooltip, @gux-zindex-tooltip);
   box-sizing: border-box;
   max-width: 250px;
   padding: 6px 12px;

--- a/src/style/css-custom-properties.less
+++ b/src/style/css-custom-properties.less
@@ -1,5 +1,6 @@
 @import (reference) './color-palette.less';
 @import (reference) './spacing.less';
+@import (reference) './zindex.less';
 
 :root {
   // Colors
@@ -121,4 +122,10 @@
   --spacing-2xl: @spacing-2xl;
   --spacing-3xl: @spacing-3xl;
   --spacing-4xl: @spacing-4xl;
+
+  // z-index
+  --gux-zindex-modal: @gux-zindex-modal;
+  --gux-zindex-popover: @gux-zindex-popover;
+  --gux-zindex-popup: @gux-zindex-popup;
+  --gux-zindex-tooltip: @gux-zindex-tooltip;
 }

--- a/src/style/zindex.less
+++ b/src/style/zindex.less
@@ -12,12 +12,14 @@
 // LESS variables are here to avoid duplicating the static defaults which will be inlined into the
 // resulting CSS.
 
-// Changing any of these values should be considered a breaking change for semver.
+// Changing default z-index values could be a breaking change for dependent apps. Be mindful!
 
 // Values here are somewhat arbitrary as these variables were factored out of existing usages that
 // used these values directly. A future breaking change should consider making the defaults higher,
-// e.g. starting at 100 so apps can use z-index 0-99 for their own content without risk of conflict.
-// See: https://inindca.atlassian.net/browse/COMUI-1171
+// and connect clearly to the existing documentation about elevation:
+// e.g. start z-indexes at 100 so apps can use 0-99 for their own content without risk of conflict
+// Elevation doc: https://spark.genesys.com/7978beca0/p/121ce3-shadows--elevation
+// https://inindca.atlassian.net/browse/COMUI-1171
 @gux-zindex-modal: 1;
 @gux-zindex-popover: 2;
 // "popup" covers any interactive picker component, e.g. dropdowns, color selectors, date pickers, etc.

--- a/src/style/zindex.less
+++ b/src/style/zindex.less
@@ -1,0 +1,25 @@
+// IMPORTANT!!!
+// These variables should typically be used as the FALLBACK value within a CSS var() expression
+// that references a CSS variable of the same name!
+//
+//   Example:
+//     .gux-some-element {
+//       z-index: var(--gux-zindex-popup, @gux-zindex-popup)
+//     }                                  ^^^^^^^^^^^^^^^^^ fallback value of the var() expression
+//
+// This pattern ensures that z-index values are overridable within consuming apps by providing a
+// new value for the CSS variable for some specific selector within that app's stylesheet. These
+// LESS variables are here to avoid duplicating the static defaults which will be inlined into the
+// resulting CSS.
+
+// Changing any of these values should be considered a breaking change for semver.
+
+// Values here are somewhat arbitrary as these variables were factored out of existing usages that
+// used these values directly. A future breaking change should consider making the defaults higher,
+// e.g. starting at 100 so apps can use z-index 0-99 for their own content without risk of conflict.
+// See: https://inindca.atlassian.net/browse/COMUI-1171
+@gux-zindex-modal: 1;
+@gux-zindex-popover: 2;
+// "popup" covers any interactive picker component, e.g. dropdowns, color selectors, date pickers, etc.
+@gux-zindex-popup: 1;
+@gux-zindex-tooltip: 1;


### PR DESCRIPTION
Define CSS variables for z-index values of raised content like
dropdowns, popovers, modals, etc. so that they can be customized within
application styles by overriding the relevant z-index variables as a
rule for a selector containing content with conflicting z-index values.