### PR TITLE
style(radio): align error label with input label

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.less
@@ -25,10 +25,20 @@
   }
 }
 
-.gux-input {
-  position: relative;
-  height: @gux-icon-size-default-global + (2 * @spacing-2xs);
-  line-height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+.gux-input-label {
+  display: flex;
+  flex-direction: row;
+
+  .gux-input {
+    position: relative;
+    height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+    line-height: @gux-icon-size-default-global + (2 * @spacing-2xs);
+  }
+
+  .gux-label {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 ::slotted(input[type='radio']) {

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
@@ -59,13 +59,17 @@ export class GuxFormFieldRadio {
         }}
       >
         <div class="gux-form-field-container">
-          <div class="gux-input">
-            <slot name="input" onSlotchange={() => this.setInput()} />
-            <slot name="label" />
+          <div class="gux-input-label">
+            <div class="gux-input">
+              <slot name="input" onSlotchange={() => this.setInput()} />
+            </div>
+            <div class="gux-label">
+              <slot name="label" />
+              <GuxFormFieldError hasError={this.hasError}>
+                <slot name="error" />
+              </GuxFormFieldError>
+            </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
-            <slot name="error" />
-          </GuxFormFieldError>
         </div>
       </Host>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.e2e.ts.snap
@@ -4,14 +4,18 @@ exports[`gux-form-field-radio #render should render component as expected (1) 1`
 
 exports[`gux-form-field-radio #render should render component as expected (1) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -21,14 +25,18 @@ exports[`gux-form-field-radio #render should render component as expected (2) 1`
 
 exports[`gux-form-field-radio #render should render component as expected (2) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -38,14 +46,18 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
 
 exports[`gux-form-field-radio #render should render component as expected (3) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error gux-show">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error gux-show">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -55,14 +67,18 @@ exports[`gux-form-field-radio #render should render component as expected (4) 1`
 
 exports[`gux-form-field-radio #render should render component as expected (4) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -72,14 +88,18 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
 
 exports[`gux-form-field-radio #render should render component as expected (5) 2`] = `
 <div class="gux-form-field-container">
-  <div class="gux-input">
-    <slot name="input"></slot>
-    <slot name="label"></slot>
-  </div>
-  <div class="gux-form-field-error gux-show">
-    <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
-    <div class="gux-message">
-      <slot name="error"></slot>
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error gux-show">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
@@ -4,14 +4,18 @@ exports[`gux-form-field-radio #render should render component as expected (1) 1`
 <gux-form-field-radio>
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -27,14 +31,18 @@ exports[`gux-form-field-radio #render should render component as expected (2) 1`
 <gux-form-field-radio class="gux-disabled">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -50,14 +58,18 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
 <gux-form-field-radio class="gux-input-error">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error gux-show">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error gux-show">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -76,14 +88,18 @@ exports[`gux-form-field-radio #render should render component as expected (4) 1`
 <gux-form-field-radio>
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -99,14 +115,18 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
 <gux-form-field-radio class="gux-input-error">
   <mock:shadow-root>
     <div class="gux-form-field-container">
-      <div class="gux-input">
-        <slot name="input"></slot>
-        <slot name="label"></slot>
-      </div>
-      <div class="gux-form-field-error gux-show">
-        <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
-        <div class="gux-message">
-          <slot name="error"></slot>
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error gux-show">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Related Task : https://inindca.atlassian.net/browse/COMUI-1166

Align error label with input label

This styling has already been applied to `form-field-checkbox`.

COMUI-1183