### PR TITLE
fix(form-field-error): adding line-height to correctly align icon an…

### DIFF
--- a/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.less
+++ b/src/components/stable/gux-form-field/functional-components/gux-form-field-error/gux-form-field-error.less
@@ -11,6 +11,7 @@
     justify-content: flex-start;
     margin: 4px 0;
     font-size: 11px;
+    line-height: 16px;
     color: @gux-black-50;
 
     &.gux-show {
@@ -23,7 +24,7 @@
       order: 0;
       width: 16px;
       height: 16px;
-      margin: 0 4px;
+      margin-right: 4px;
       color: @gux-alert-red-60;
     }
 


### PR DESCRIPTION
Related Task : https://inindca.atlassian.net/browse/COMUI-1185

The fixes in this change were applied to all form-field components and not just radio/checkbox.

The fixes were as follows,

1. Addition of line-height to the error slot content to correctly align the error message to the error icon. A line-height of 16px was applied to the error slot content to match height of icon. What are your thoughts on this ? The line-height on the spark website is 20px but maybe 16px works better?

3. Removal of a 4px margin to the left of the error icon so that the icon will lineup to the input correctly.
