### PR TITLE
fix(calendar): calendar skipping month for some dates

### DIFF
--- a/src/components/stable/gux-calendar/gux-calendar.tsx
+++ b/src/components/stable/gux-calendar/gux-calendar.tsx
@@ -148,6 +148,7 @@ export class GuxCalendar {
 
   getMonthLabel(index: number) {
     const month = new Date(this.previewValue.getTime());
+    month.setDate(1);
     month.setMonth(month.getMonth() + index);
     const monthName = month.toLocaleString(this.locale, { month: 'long' });
     return monthName.charAt(0).toUpperCase() + monthName.slice(1);
@@ -269,6 +270,7 @@ export class GuxCalendar {
 
   getMonthDays(index: number): IDateElement[][] {
     const month = new Date(this.previewValue.getTime());
+    month.setDate(1);
     month.setMonth(month.getMonth() + index);
     const monthIndex = month.getMonth();
     const year = month.getFullYear();

--- a/src/components/stable/gux-calendar/tests/gux-calendar.e2e.ts
+++ b/src/components/stable/gux-calendar/tests/gux-calendar.e2e.ts
@@ -26,4 +26,30 @@ describe('gux-calendar', () => {
     const firstDayOfWeek = await element.find('pierce/th');
     expect(firstDayOfWeek.innerText).toEqual('L');
   });
+
+  it('should render the correct months when using a range calendar', async () => {
+    const page = await newSparkE2EPage({
+      html: `<gux-calendar mode="range" number-of-months="2" value="2022-08-31/2022-09-06">
+      </gux-calendar>`
+    });
+    const element = await page.find('gux-calendar');
+    const monthList = element.shadowRoot.querySelector('.gux-month-list');
+
+    expect(monthList).toEqualHtml(
+      '<div class="gux-month-list"><label>August 2022</label><label>September 2022</label></div>'
+    );
+  });
+
+  it('should render the correct months when using a range calendar', async () => {
+    const page = await newSparkE2EPage({
+      html: `<gux-calendar mode="range" number-of-months="2" value="2022-05-31/2022-06-06">
+      </gux-calendar>`
+    });
+    const element = await page.find('gux-calendar');
+    const monthList = element.shadowRoot.querySelector('.gux-month-list');
+
+    expect(monthList).toEqualHtml(
+      '<div class="gux-month-list"><label>May 2022</label><label>June 2022</label></div>'
+    );
+  });
 });


### PR DESCRIPTION
calendar skipping month for some dates.

Related Task:  https://inindca.atlassian.net/browse/COMUI-1193

**Issue**: Calendar skipping months for some dates. This is due to the calculations happening within `gux-calendar`. The render functions runs twice once for the left side of the calendar and once for the right side of the calendar when you select a date. So for example if I select the 31st of August the calculation will be based off 31 days for the right side also but seeing as september does not have 31 days it will push it out to the next month which results in october being displayed. 

Fix:
Set calculation to be based off the first date in the month regardless of what is selected. 

COMUI-1193