### PR TITLE
feat(gux-toggle): enable preventDefault on check events

### DIFF
--- a/src/components/stable/gux-toggle/gux-toggle.tsx
+++ b/src/components/stable/gux-toggle/gux-toggle.tsx
@@ -76,9 +76,10 @@ export class GuxToggle {
 
   private toggle(): void {
     if (!this.disabled && !this.loading) {
-      this.checked = !this.checked;
-
-      this.check.emit(this.checked);
+      const checkEvent = this.check.emit(this.checked);
+      if (!checkEvent.defaultPrevented) {
+        this.checked = !this.checked;
+      }
     }
   }
 

--- a/src/components/stable/gux-toggle/tests/gux-toggle.e2e.ts
+++ b/src/components/stable/gux-toggle/tests/gux-toggle.e2e.ts
@@ -169,6 +169,25 @@ describe('gux-toggle', () => {
 
           expect(await element.getProperty('checked')).toBe(true);
         });
+
+        it(`should not check the toggle if preventDefault is called on the event`, async () => {
+          const html =
+            '<gux-toggle lang="en" checked-label="On" unchecked-label="Off"></gux-toggle>';
+          const page: E2EPage = await newNonrandomE2EPage({ html });
+          const element: E2EElement = await page.find('gux-toggle');
+          await page.evaluate(() => {
+            document.addEventListener('check', event => {
+              event.preventDefault();
+            });
+          });
+
+          expect(await element.getProperty('checked')).toBe(false);
+
+          await userInteraction(element);
+          await page.waitForChanges();
+
+          expect(await element.getProperty('checked')).toBe(false);
+        });
       });
     });
   });


### PR DESCRIPTION
When `preventDefault()` is called on check events, the toggle's state will not change

COMUI-1002

I'll make another PR to backport to V2