### PR TITLE
fix(option): remove whitespace from text of gux-options.

### DIFF
--- a/src/components/stable/gux-dropdown/gux-dropdown.tsx
+++ b/src/components/stable/gux-dropdown/gux-dropdown.tsx
@@ -281,7 +281,8 @@ export class GuxDropdown {
       const option = getSearchOption(this.listboxElement, filter);
 
       if (option) {
-        return option.textContent.substring(filterLength);
+        //The text content needs to be trimmed as white space can occur around the textContent if options are populated asynchronously.
+        return option.textContent.trim().substring(filterLength);
       }
     }
 

--- a/src/components/stable/gux-listbox/gux-listbox.service.ts
+++ b/src/components/stable/gux-listbox/gux-listbox.service.ts
@@ -105,7 +105,7 @@ export function getSearchOption(
   return getListOptions(list).find(option => {
     return (
       (!option.disabled || !option.filtered) &&
-      option.textContent.toLowerCase().startsWith(searchString.toLowerCase())
+      matchOption(option, searchString)
     );
   });
 }
@@ -216,4 +216,15 @@ export function goToOption(list: HTMLGuxListboxElement, letter: string): void {
     setSearchOptionActive(list, searchStringState);
     searchStringState = '';
   }, searchDebounceInterval);
+}
+
+export function matchOption(
+  option: HTMLGuxOptionElement,
+  matchString: string
+): boolean {
+  //The text content needs to be trimmed as white space can occur around the textContent if options are populated asynchronously.
+  return option.textContent
+    .trim()
+    .toLowerCase()
+    .startsWith(matchString.toLowerCase());
 }

--- a/src/components/stable/gux-listbox/gux-listbox.tsx
+++ b/src/components/stable/gux-listbox/gux-listbox.tsx
@@ -23,7 +23,8 @@ import {
   setInitialActiveOption,
   setLastOptionActive,
   setNextOptionActive,
-  setPreviousOptionActive
+  setPreviousOptionActive,
+  matchOption
 } from './gux-listbox.service';
 
 import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
@@ -184,10 +185,7 @@ export class GuxListbox {
   componentWillRender(): void {
     this.listboxOptions.forEach(listboxOption => {
       listboxOption.selected = listboxOption.value === this.value;
-
-      listboxOption.filtered = !listboxOption.textContent
-        .toLowerCase()
-        .startsWith(this.filter.toLowerCase());
+      listboxOption.filtered = !matchOption(listboxOption, this.filter);
     });
 
     this.allListboxOptionsFiltered =


### PR DESCRIPTION
Related Task : https://inindca.atlassian.net/browse/COMUI-1132

**Issue:**
This issue was identified in angular.
When options are loaded asynchronously the text has whitespace on either side of the text. This will prevent the filter operation from working.

**Resolution:**
Removed whitespace for text content of gux-options.