### PR TITLE
feat(form-field) - addition of help slot

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/example.html
@@ -44,7 +44,13 @@
     <gux-form-field-checkbox>
       <input slot="input" type="checkbox" name="food-1[]" value="sushi" />
       <label slot="label">Sushi</label>
-      <span slot="error">Subject to availibility</span>
+      <span slot="error">Subject to availability</span>
+    </gux-form-field-checkbox>
+
+    <gux-form-field-checkbox>
+      <input slot="input" type="checkbox" name="food-1[]" value="spaghetti" />
+      <label slot="label">Spaghetti</label>
+      <span slot="help">This is a help message</span>
     </gux-form-field-checkbox>
   </fieldset>
 </form>

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.less
@@ -4,8 +4,11 @@
 @import (reference) '../../../../../style/variables.less';
 @import (reference)
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldErrorStyle();
+.GuxFormFieldHelpStyle();
 
 @gux-icon-checkbox-unchecked: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.3077 1.84615H3.69231C2.67271 1.84615 1.84615 2.67271 1.84615 3.69231V12.3077C1.84615 13.3273 2.67271 14.1538 3.69231 14.1538H12.3077C13.3273 14.1538 14.1538 13.3273 14.1538 12.3077V3.69231C14.1538 2.67271 13.3273 1.84615 12.3077 1.84615ZM3.69231 0C1.6531 0 0 1.6531 0 3.69231V12.3077C0 14.3469 1.6531 16 3.69231 16H12.3077C14.3469 16 16 14.3469 16 12.3077V3.69231C16 1.6531 14.3469 0 12.3077 0H3.69231Z' fill='%2377828f'/%3E%3C/svg%3E");
 @gux-icon-checkbox-unchecked-hover: url("data:image/svg+xml,%3Csvg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12.3077 1.84615H3.69231C2.67271 1.84615 1.84615 2.67271 1.84615 3.69231V12.3077C1.84615 13.3273 2.67271 14.1538 3.69231 14.1538H12.3077C13.3273 14.1538 14.1538 13.3273 14.1538 12.3077V3.69231C14.1538 2.67271 13.3273 1.84615 12.3077 1.84615ZM3.69231 0C1.6531 0 0 1.6531 0 3.69231V12.3077C0 14.3469 1.6531 16 3.69231 16H12.3077C14.3469 16 16 14.3469 16 12.3077V3.69231C16 1.6531 14.3469 0 12.3077 0H3.69231Z' fill='%232a60c8'/%3E%3C/svg%3E");

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
@@ -1,19 +1,24 @@
 import { Component, Element, h, Host, JSX, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
+
+import {
+  GuxFormFieldError,
+  GuxFormFieldHelp
+} from '../../functional-components/functional-components';
+
 import { trackComponent } from '../../../../../usage-tracking';
-
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-
-import { hasErrorSlot, validateFormIds } from '../../gux-form-field.service';
+import { validateFormIds } from '../../gux-form-field.service';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-checkbox.less',
@@ -33,15 +38,20 @@ export class GuxFormFieldCheckbox {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root);
   }
@@ -65,9 +75,12 @@ export class GuxFormFieldCheckbox {
             </div>
             <div class="gux-label">
               <slot name="label" />
-              <GuxFormFieldError hasError={this.hasError}>
+              <GuxFormFieldError show={this.hasError}>
                 <slot name="error" />
               </GuxFormFieldError>
+              <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+                <slot name="help" />
+              </GuxFormFieldHelp>
             </div>
           </div>
         </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/readme.md
@@ -10,6 +10,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.e2e.ts.snap
@@ -16,6 +16,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -35,6 +40,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
         <div class="gux-message">
           <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
         </div>
       </div>
     </div>
@@ -58,6 +68,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -79,6 +94,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -98,6 +118,37 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
         <div class="gux-message">
           <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`gux-form-field-checkbox #render should render component as expected (6) 1`] = `"<gux-form-field-checkbox hydrated=\\"\\"> <input slot=\\"input\\" type=\\"checkbox\\" name=\\"food-1[]\\" value=\\"pizza\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Pizza</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-checkbox>"`;
+
+exports[`gux-form-field-checkbox #render should render component as expected (6) 2`] = `
+<div class="gux-form-field-container">
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help gux-show">
+        <div class="gux-message">
+          <slot name="help"></slot>
         </div>
       </div>
     </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/__snapshots__/gux-form-field-checkbox.spec.ts.snap
@@ -16,6 +16,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (1)
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -43,6 +48,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (2)
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -68,6 +78,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (3)
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
+            </div>
+          </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
             </div>
           </div>
         </div>
@@ -100,6 +115,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (4)
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -127,6 +147,11 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -137,6 +162,41 @@ exports[`gux-form-field-checkbox #render should render component as expected (5)
   </label>
   <span id="gux-form-field-error-i" slot="error">
     Error message
+  </span>
+</gux-form-field-checkbox>
+`;
+
+exports[`gux-form-field-checkbox #render should render component as expected (6) 1`] = `
+<gux-form-field-checkbox>
+  <mock:shadow-root>
+    <div class="gux-form-field-container">
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
+          <div class="gux-form-field-help gux-show">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="food-1[]" slot="input" type="checkbox" value="pizza">
+  <label for="gux-form-field-input-i" slot="label">
+    Pizza
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
   </span>
 </gux-form-field-checkbox>
 `;

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.e2e.ts
@@ -56,7 +56,14 @@ describe('gux-form-field-checkbox', () => {
           <label slot="label">Pizza</label>
           <span slot="error">Error message</span>
         </gux-form-field-checkbox>
+      `,
       `
+      <gux-form-field-checkbox>
+        <input slot="input" type="checkbox" name="food-1[]" value="pizza"/>
+        <label slot="label">Pizza</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-checkbox>
+    `
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newNonrandomE2EPage({ html });

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/tests/gux-form-field-checkbox.spec.ts
@@ -60,7 +60,14 @@ describe('gux-form-field-checkbox', () => {
           <label slot="label">Pizza</label>
           <span slot="error">Error message</span>
         </gux-form-field-checkbox>
+      `,
       `
+      <gux-form-field-checkbox>
+        <input slot="input" type="checkbox" name="food-1[]" value="pizza"/>
+        <label slot="label">Pizza</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-checkbox>
+    `
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/example.html
@@ -56,6 +56,16 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-color>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-color>
+      <input slot="input" type="color" name="e-1" value="#cc3ebe" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-color>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.tsx
@@ -1,27 +1,31 @@
 import { Component, Element, h, JSX, Prop, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
   getComputedLabelPosition,
-  hasErrorSlot,
   validateFormIds
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-color.less',
@@ -52,16 +56,21 @@ export class GuxFormFieldColor {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -96,9 +105,12 @@ export class GuxFormFieldColor {
               <slot name="input" onSlotchange={() => this.setInput()} />
             </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/readme.md
@@ -17,6 +17,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.e2e.ts.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-color #render help should render component as expected 1`] = `"<gux-form-field-color hydrated=\\"\\"> <input slot=\\"input\\" type=\\"color\\" name=\\"e-1\\" value=\\"#cc3ebe\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-color>"`;
+
+exports[`gux-form-field-color #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input">
+      <div class="gux-input-container">
+        <slot name="input"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`gux-form-field-color #render input attributes should render component as expected (1) 1`] = `"<gux-form-field-color hydrated=\\"\\"> <input slot=\\"input\\" type=\\"color\\" value=\\"#ff0000\\" id=\\"gux-form-field-input-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Label</label> </gux-form-field-color>"`;
 
 exports[`gux-form-field-color #render input attributes should render component as expected (1) 2`] = `
@@ -17,6 +45,11 @@ exports[`gux-form-field-color #render input attributes should render component a
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -42,6 +75,11 @@ exports[`gux-form-field-color #render input attributes should render component a
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -63,6 +101,11 @@ exports[`gux-form-field-color #render input attributes should render component a
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -88,6 +131,11 @@ exports[`gux-form-field-color #render label-position should render component as 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -109,6 +157,11 @@ exports[`gux-form-field-color #render label-position should render component as 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -134,6 +187,11 @@ exports[`gux-form-field-color #render label-position should render component as 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -155,6 +213,11 @@ exports[`gux-form-field-color #render label-position should render component as 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/tests/__snapshots__/gux-form-field-color.spec.ts.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-color #render help should render component as expected 1`] = `
+<gux-form-field-color>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="e-1" slot="input" type="color" value="#cc3ebe">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-color>
+`;
+
 exports[`gux-form-field-color #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-color>
   <mock:shadow-root>
@@ -17,6 +54,11 @@ exports[`gux-form-field-color #render input attributes should render component a
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -48,6 +90,11 @@ exports[`gux-form-field-color #render input attributes should render component a
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -75,6 +122,11 @@ exports[`gux-form-field-color #render input attributes should render component a
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -106,6 +158,11 @@ exports[`gux-form-field-color #render label-position should render component as 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -133,6 +190,11 @@ exports[`gux-form-field-color #render label-position should render component as 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -164,6 +226,11 @@ exports[`gux-form-field-color #render label-position should render component as 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -191,6 +258,11 @@ exports[`gux-form-field-color #render label-position should render component as 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.e2e.ts
@@ -84,5 +84,32 @@ describe('gux-form-field-color', () => {
         });
       });
     });
+
+    describe('help', () => {
+      const html = `
+      <gux-form-field-color>
+      <input slot="input" type="color" name="e-1" value="#cc3ebe" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-color>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-color');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/tests/gux-form-field-color.spec.ts
@@ -65,5 +65,20 @@ describe('gux-form-field-color', () => {
         });
       });
     });
+
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-color>
+        <input slot="input" type="color" name="e-1" value="#cc3ebe" />
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-color>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/example.html
@@ -139,6 +139,32 @@
     </gux-form-field-dropdown>
   </fieldset>
 
+  <fieldset>
+    <legend>Help</legend>
+    <gux-form-field-dropdown>
+      <gux-dropdown>
+        <gux-listbox>
+          <gux-option value="a" disabled>Ant</gux-option>
+          <gux-option value="b">Bat</gux-option>
+          <gux-option value="c">Cat</gux-option>
+        </gux-listbox>
+      </gux-dropdown>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-dropdown>
+    <gux-form-field-dropdown>
+      <gux-dropdown required>
+        <gux-listbox>
+          <gux-option value="a" disabled>Ant</gux-option>
+          <gux-option value="b">Bat</gux-option>
+          <gux-option value="c">Cat</gux-option>
+        </gux-listbox>
+      </gux-dropdown>
+      <label slot="label">Required</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-dropdown>
+  </fieldset>
+
   <h2>Dropdown (multi select)</h2>
   <p>
     slot a gux-dropdown-multi-beta element into a gux-form-field-dropdown
@@ -272,6 +298,32 @@
       </gux-dropdown-multi-beta>
       <label slot="label">Required</label>
       <span slot="error">This is an error message</span>
+    </gux-form-field-dropdown>
+  </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+    <gux-form-field-dropdown>
+      <gux-dropdown-multi-beta>
+        <gux-listbox-multi>
+          <gux-option-multi value="a" disabled>Ant</gux-option-multi>
+          <gux-option-multi value="b">Bat</gux-option-multi>
+          <gux-option-multi value="c">Cat</gux-option-multi>
+        </gux-listbox-multi>
+      </gux-dropdown-multi-beta>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-dropdown>
+    <gux-form-field-dropdown>
+      <gux-dropdown-multi-beta required>
+        <gux-listbox-multi>
+          <gux-option-multi value="a" disabled>Ant</gux-option-multi>
+          <gux-option-multi value="b">Bat</gux-option-multi>
+          <gux-option-multi value="c">Cat</gux-option-multi>
+        </gux-listbox-multi>
+      </gux-dropdown-multi-beta>
+      <label slot="label">Required</label>
+      <span slot="help">This is a help message</span>
     </gux-form-field-dropdown>
   </fieldset>
 </form>

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.tsx
@@ -1,26 +1,30 @@
 import { Component, Element, h, JSX, Prop, State, Watch } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
-  hasErrorSlot,
   getComputedLabelPosition,
   validateFormIds
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-dropdown.less',
@@ -54,6 +58,9 @@ export class GuxFormFieldDropdown {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @Watch('hasError')
   watchValue(hasError: boolean): void {
     const dropdownSlot =
@@ -66,14 +73,16 @@ export class GuxFormFieldDropdown {
 
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -102,9 +111,12 @@ export class GuxFormFieldDropdown {
           >
             <slot />
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/readme.md
@@ -17,6 +17,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.e2e.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-dropdown #render help should render component as expected 1`] = `"<gux-form-field-dropdown hydrated=\\"\\"> <gux-dropdown hydrated=\\"\\"> <gux-listbox id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\" role=\\"listbox\\" tabindex=\\"0\\" hydrated=\\"\\"> <gux-option value=\\"a\\" disabled=\\"\\" id=\\"gux-option-i\\" role=\\"option\\" class=\\"gux-disabled\\" aria-disabled=\\"true\\" hydrated=\\"\\"><!---->Ant</gux-option> <gux-option value=\\"b\\" id=\\"gux-option-i\\" role=\\"option\\" aria-selected=\\"false\\" aria-disabled=\\"false\\" hydrated=\\"\\"><!---->Bat</gux-option> <gux-option value=\\"c\\" id=\\"gux-option-i\\" role=\\"option\\" aria-selected=\\"false\\" aria-disabled=\\"false\\" hydrated=\\"\\"><!---->Cat</gux-option> </gux-listbox> </gux-dropdown> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-dropdown>"`;
+
+exports[`gux-form-field-dropdown #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input">
+      <slot></slot>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`gux-form-field-dropdown #render multi select dropdown label-position should render component as expected (1) 1`] = `"<gux-form-field-dropdown hydrated=\\"\\"> <gux-dropdown-multi-beta hydrated=\\"\\"> <gux-listbox-multi id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-error-i\\" role=\\"listbox\\" aria-multiselectable=\\"true\\" tabindex=\\"0\\" hydrated=\\"\\"> <gux-option-multi value=\\"a\\" disabled=\\"\\" id=\\"gux-option-multi-i\\" role=\\"option\\" class=\\"gux-disabled\\" aria-disabled=\\"true\\" hydrated=\\"\\"><!----><div class=\\"gux-option\\">Ant</div></gux-option-multi> <gux-option-multi value=\\"b\\" id=\\"gux-option-multi-i\\" role=\\"option\\" aria-selected=\\"false\\" aria-disabled=\\"false\\" hydrated=\\"\\"><!----><div class=\\"gux-option\\">Bat</div></gux-option-multi> <gux-option-multi value=\\"c\\" id=\\"gux-option-multi-i\\" role=\\"option\\" aria-selected=\\"false\\" aria-disabled=\\"false\\" hydrated=\\"\\"><!----><div class=\\"gux-option\\">Cat</div></gux-option-multi> </gux-listbox-multi> </gux-dropdown-multi-beta> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"error\\" id=\\"gux-form-field-error-i\\">This is an error message</span> </gux-form-field-dropdown>"`;
 
 exports[`gux-form-field-dropdown #render multi select dropdown label-position should render component as expected (1) 2`] = `
@@ -15,6 +41,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown label-position sh
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -38,6 +69,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown label-position sh
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -57,6 +93,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown label-position sh
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -80,6 +121,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown label-position sh
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -99,6 +145,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown should render com
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -122,6 +173,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown should render com
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -141,6 +197,11 @@ exports[`gux-form-field-dropdown #render multi select dropdown should render com
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -164,6 +225,11 @@ exports[`gux-form-field-dropdown #render single select dropdown input attributes
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -183,6 +249,11 @@ exports[`gux-form-field-dropdown #render single select dropdown input attributes
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -206,6 +277,11 @@ exports[`gux-form-field-dropdown #render single select dropdown input attributes
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -225,6 +301,11 @@ exports[`gux-form-field-dropdown #render single select dropdown label-position s
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -248,6 +329,11 @@ exports[`gux-form-field-dropdown #render single select dropdown label-position s
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -269,6 +355,11 @@ exports[`gux-form-field-dropdown #render single select dropdown label-position s
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -288,6 +379,11 @@ exports[`gux-form-field-dropdown #render single select dropdown label-position s
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/__snapshots__/gux-form-field-dropdown.spec.ts.snap
@@ -1,5 +1,153 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-select multi select dropdown #render help multi select should render component as expected 1`] = `
+<gux-form-field-dropdown>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <slot></slot>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <gux-dropdown-multi-beta>
+    <mock:shadow-root>
+      <div class="gux-dropdown-container">
+        <gux-popup>
+          <div class="gux-target-container gux-target-container-collapsed" slot="target">
+            <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
+              <div class="gux-field-content">
+                <div class="gux-placeholder">
+                  Select...
+                </div>
+              </div>
+              <gux-icon class="gux-expand-icon" iconname="chevron-small-down" screenreader-text="Dropdown"></gux-icon>
+            </button>
+          </div>
+          <div class="gux-listbox-container" slot="popup">
+            <slot></slot>
+          </div>
+        </gux-popup>
+      </div>
+    </mock:shadow-root>
+    <gux-listbox-multi aria-describedby="gux-form-field-help-i" aria-multiselectable="true" id="gux-form-field-input-i" role="listbox" tabindex="0">
+      <mock:shadow-root>
+        <slot></slot>
+      </mock:shadow-root>
+      <gux-option-multi aria-disabled="true" class="gux-disabled" disabled="" id="gux-option-multi-i" role="option" value="a">
+        <!---->
+        <div class="gux-option">
+          Ant
+        </div>
+      </gux-option-multi>
+      <gux-option-multi aria-disabled="false" aria-selected="false" id="gux-option-multi-i" role="option" value="b">
+        <!---->
+        <div class="gux-option">
+          Bat
+        </div>
+      </gux-option-multi>
+      <gux-option-multi aria-disabled="false" aria-selected="false" id="gux-option-multi-i" role="option" value="c">
+        <!---->
+        <div class="gux-option">
+          Cat
+        </div>
+      </gux-option-multi>
+    </gux-listbox-multi>
+  </gux-dropdown-multi-beta>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-dropdown>
+`;
+
+exports[`gux-form-field-select multi select dropdown #render help should render component as expected 1`] = `
+<gux-form-field-dropdown>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <slot></slot>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <gux-dropdown>
+    <mock:shadow-root>
+      <gux-popup>
+        <div class="gux-target-container-collapsed" slot="target">
+          <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
+            <div class="gux-field-content">
+              <div class="gux-placeholder">
+                Select...
+              </div>
+            </div>
+            <gux-icon class="gux-expand-icon" iconname="chevron-small-down" screenreader-text="Dropdown"></gux-icon>
+          </button>
+        </div>
+        <div class="gux-listbox-container" slot="popup">
+          <slot></slot>
+        </div>
+      </gux-popup>
+    </mock:shadow-root>
+    <gux-listbox aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" role="listbox" tabindex="0">
+      <mock:shadow-root>
+        <slot></slot>
+      </mock:shadow-root>
+      <gux-option aria-disabled="true" class="gux-disabled" disabled="" id="gux-option-i" role="option" value="a">
+        <!---->
+        Ant
+      </gux-option>
+      <gux-option aria-disabled="false" aria-selected="false" id="gux-option-i" role="option" value="b">
+        <!---->
+        Bat
+      </gux-option>
+      <gux-option aria-disabled="false" aria-selected="false" id="gux-option-i" role="option" value="c">
+        <!---->
+        Cat
+      </gux-option>
+    </gux-listbox>
+  </gux-dropdown>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-dropdown>
+`;
+
 exports[`gux-form-field-select multi select dropdown #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-dropdown>
   <mock:shadow-root>
@@ -15,6 +163,11 @@ exports[`gux-form-field-select multi select dropdown #render input attributes sh
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -87,6 +240,11 @@ exports[`gux-form-field-select multi select dropdown #render input attributes sh
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -155,6 +313,11 @@ exports[`gux-form-field-select multi select dropdown #render input attributes sh
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -227,6 +390,11 @@ exports[`gux-form-field-select multi select dropdown #render label-position shou
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -295,6 +463,11 @@ exports[`gux-form-field-select multi select dropdown #render label-position shou
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -367,6 +540,11 @@ exports[`gux-form-field-select multi select dropdown #render label-position shou
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -435,6 +613,11 @@ exports[`gux-form-field-select multi select dropdown #render label-position shou
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -507,6 +690,11 @@ exports[`gux-form-field-select single select dropdown #render input attributes s
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -567,6 +755,11 @@ exports[`gux-form-field-select single select dropdown #render input attributes s
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -631,6 +824,11 @@ exports[`gux-form-field-select single select dropdown #render input attributes s
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -691,6 +889,11 @@ exports[`gux-form-field-select single select dropdown #render label-position sho
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -755,6 +958,11 @@ exports[`gux-form-field-select single select dropdown #render label-position sho
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -817,6 +1025,11 @@ exports[`gux-form-field-select single select dropdown #render label-position sho
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -877,6 +1090,11 @@ exports[`gux-form-field-select single select dropdown #render label-position sho
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/gux-form-field-dropdown.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/gux-form-field-dropdown.e2e.ts
@@ -24,6 +24,38 @@ async function newNonrandomE2EPage({
 
 describe('gux-form-field-dropdown', () => {
   describe('#render', () => {
+    describe('help', () => {
+      const html = `
+      <gux-form-field-dropdown>
+      <gux-dropdown>
+        <gux-listbox>
+          <gux-option value="a" disabled>Ant</gux-option>
+          <gux-option value="b">Bat</gux-option>
+          <gux-option value="c">Cat</gux-option>
+        </gux-listbox>
+      </gux-dropdown>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-dropdown>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-dropdown');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
     describe('single select dropdown', () => {
       describe('label-position', () => {
         [

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/gux-form-field-dropdown.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/tests/gux-form-field-dropdown.spec.ts
@@ -168,6 +168,48 @@ describe('gux-form-field-select', () => {
           });
         });
       });
+
+      describe('help', () => {
+        it('should render component as expected', async () => {
+          const html = `
+          <gux-form-field-dropdown>
+          <gux-dropdown>
+            <gux-listbox>
+              <gux-option value="a" disabled>Ant</gux-option>
+              <gux-option value="b">Bat</gux-option>
+              <gux-option value="c">Cat</gux-option>
+            </gux-listbox>
+          </gux-dropdown>
+          <label slot="label">Default</label>
+          <span slot="help">This is a help message</span>
+        </gux-form-field-dropdown>
+          `;
+          const page = await newSpecPage({ components, html, language });
+
+          expect(page.root).toMatchSnapshot();
+        });
+      });
+
+      describe('help multi select', () => {
+        it('should render component as expected', async () => {
+          const html = `
+          <gux-form-field-dropdown>
+          <gux-dropdown-multi-beta>
+            <gux-listbox-multi>
+              <gux-option-multi value="a" disabled>Ant</gux-option-multi>
+              <gux-option-multi value="b">Bat</gux-option-multi>
+              <gux-option-multi value="c">Cat</gux-option-multi>
+            </gux-listbox-multi>
+          </gux-dropdown-multi-beta>
+          <label slot="label">Default</label>
+          <span slot="help">This is a help message</span>
+        </gux-form-field-dropdown>
+          `;
+          const page = await newSpecPage({ components, html, language });
+
+          expect(page.root).toMatchSnapshot();
+        });
+      });
     });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/example.html
@@ -100,6 +100,16 @@
   </fieldset>
 
   <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-number>
+      <input slot="input" type="number" name="e-1" value="10" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-number>
+  </fieldset>
+
+  <fieldset>
     <legend>Programmatically set value</legend>
 
     <gux-form-field-number id="p" clearable>

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
@@ -11,34 +11,38 @@ import {
 
 import { buildI18nForComponent, GetI18nValue } from '../../../../../i18n';
 import { ILocalizedComponentResources } from '../../../../../i18n/fetchResources';
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
-import setInputValue from '../../../../../utils/dom/set-input-value';
-import simulateNativeEvent from '../../../../../utils/dom/simulate-native-event';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import setInputValue from '@utils/dom/set-input-value';
+import simulateNativeEvent from '@utils/dom/simulate-native-event';
+import { hasSlot } from '@utils/dom/has-slot';
+
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
   clearInput,
   getComputedLabelPosition,
   hasContent,
-  hasErrorSlot,
   validateFormIds
 } from '../../gux-form-field.service';
-
+import { trackComponent } from '../../../../../usage-tracking';
 import componentResources from './i18n/en.json';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  * @part input-section - Style input container
  */
 @Component({
@@ -77,16 +81,21 @@ export class GuxFormFieldNumber {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   @Method()
   async guxForceUpdate(): Promise<void> {
     this.hasContent = hasContent(this.input);
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     forceUpdate(this.root);
   }
@@ -100,7 +109,8 @@ export class GuxFormFieldNumber {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -149,9 +159,12 @@ export class GuxFormFieldNumber {
               this.disabled
             )}
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/readme.md
@@ -31,6 +31,7 @@ Type: `Promise<void>`
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.e2e.ts.snap
@@ -27,6 +27,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -57,6 +62,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -91,6 +101,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -120,6 +135,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -153,6 +173,47 @@ exports[`gux-form-field-number #render clearable should render component as expe
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`gux-form-field-number #render help should render component as expected 1`] = `"<gux-form-field-number hydrated=\\"\\"> <input slot=\\"input\\" type=\\"number\\" name=\\"e-1\\" value=\\"10\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-number>"`;
+
+exports[`gux-form-field-number #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input" part="input-section">
+      <div class="gux-input-container">
+        <slot name="input"></slot>
+      </div>
+      <div class="gux-step-buttons-container">
+        <button class="gux-step-button" tabindex="-1" title="Increment" type="button">
+          <gux-icon hydrated="" icon-name="chevron-small-up"></gux-icon>
+        </button>
+        <button class="gux-step-button" tabindex="-1" title="Decrement" type="button">
+          <gux-icon hydrated="" icon-name="chevron-small-down"></gux-icon>
+        </button>
+      </div>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -182,6 +243,11 @@ exports[`gux-form-field-number #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -215,6 +281,11 @@ exports[`gux-form-field-number #render input attributes should render component 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -244,6 +315,11 @@ exports[`gux-form-field-number #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -277,6 +353,11 @@ exports[`gux-form-field-number #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -306,6 +387,11 @@ exports[`gux-form-field-number #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -339,6 +425,11 @@ exports[`gux-form-field-number #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -368,6 +459,11 @@ exports[`gux-form-field-number #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/tests/__snapshots__/gux-form-field-number.spec.ts.snap
@@ -27,6 +27,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -63,6 +68,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -103,6 +113,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -138,6 +153,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -177,6 +197,11 @@ exports[`gux-form-field-number #render clearable should render component as expe
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -184,6 +209,51 @@ exports[`gux-form-field-number #render clearable should render component as expe
   <label for="gux-form-field-input-i" slot="label">
     Label
   </label>
+</gux-form-field-number>
+`;
+
+exports[`gux-form-field-number #render help should render component as expected 1`] = `
+<gux-form-field-number>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input" part="input-section">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+          </div>
+          <div class="gux-step-buttons-container">
+            <button class="gux-step-button" tabindex="-1" title="Increment" type="button">
+              <gux-icon decorative="" icon-name="chevron-small-up"></gux-icon>
+            </button>
+            <button class="gux-step-button" tabindex="-1" title="Decrement" type="button">
+              <gux-icon decorative="" icon-name="chevron-small-down"></gux-icon>
+            </button>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="e-1" slot="input" type="number" value="10">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
 </gux-form-field-number>
 `;
 
@@ -212,6 +282,11 @@ exports[`gux-form-field-number #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -251,6 +326,11 @@ exports[`gux-form-field-number #render input attributes should render component 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -286,6 +366,11 @@ exports[`gux-form-field-number #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -325,6 +410,11 @@ exports[`gux-form-field-number #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -360,6 +450,11 @@ exports[`gux-form-field-number #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -399,6 +494,11 @@ exports[`gux-form-field-number #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -434,6 +534,11 @@ exports[`gux-form-field-number #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.e2e.ts
@@ -118,5 +118,32 @@ describe('gux-form-field-number', () => {
         });
       });
     });
+
+    describe('help', () => {
+      const html = `
+      <gux-form-field-number>
+      <input slot="input" type="number" name="e-1" value="10" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-number>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-number');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/tests/gux-form-field-number.spec.ts
@@ -87,5 +87,20 @@ describe('gux-form-field-number', () => {
         });
       });
     });
+
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-number>
+        <input slot="input" type="number" name="e-1" value="10" />
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-number>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/example.html
@@ -38,6 +38,12 @@
       <label slot="label">Sushi</label>
       <span slot="error">Subject to availibility</span>
     </gux-form-field-radio>
+
+    <gux-form-field-radio>
+      <input slot="input" type="radio" name="food-1" value="spaghetti" />
+      <label slot="label">Spaghetti</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-radio>
   </fieldset>
 </form>
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.less
@@ -4,8 +4,11 @@
 @import (reference) '../../../../../style/variables.less';
 @import (reference)
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldErrorStyle();
+.GuxFormFieldHelpStyle();
 
 @gux-icon-radio-unchecked: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 3.062C5.239 3.062 3 5.273 3 8s2.239 4.938 5 4.938c2.762 0 5-2.211 5-4.938s-2.238-4.938-5-4.938zm0 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z' fill-rule='evenodd' clip-rule='evenodd' fill='%2377828f'/%3E%3C/svg%3E");
 @gux-icon-radio-unchecked-hover: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 3.062C5.239 3.062 3 5.273 3 8s2.239 4.938 5 4.938c2.762 0 5-2.211 5-4.938s-2.238-4.938-5-4.938zm0 9a4 4 0 1 1 0-8 4 4 0 0 1 0 8z' fill-rule='evenodd' clip-rule='evenodd' fill='%232a60c8'/%3E%3C/svg%3E");

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
@@ -1,19 +1,24 @@
 import { Component, Element, h, Host, JSX, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
+
+import {
+  GuxFormFieldError,
+  GuxFormFieldHelp
+} from '../../functional-components/functional-components';
+
+import { validateFormIds } from '../../gux-form-field.service';
 import { trackComponent } from '../../../../../usage-tracking';
-
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-
-import { hasErrorSlot, validateFormIds } from '../../gux-form-field.service';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-radio.less',
@@ -33,15 +38,20 @@ export class GuxFormFieldRadio {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root);
   }
@@ -65,9 +75,12 @@ export class GuxFormFieldRadio {
             </div>
             <div class="gux-label">
               <slot name="label" />
-              <GuxFormFieldError hasError={this.hasError}>
+              <GuxFormFieldError show={this.hasError}>
                 <slot name="error" />
               </GuxFormFieldError>
+              <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+                <slot name="help" />
+              </GuxFormFieldHelp>
             </div>
           </div>
         </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/readme.md
@@ -10,6 +10,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.e2e.ts.snap
@@ -16,6 +16,11 @@ exports[`gux-form-field-radio #render should render component as expected (1) 2`
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -35,6 +40,11 @@ exports[`gux-form-field-radio #render should render component as expected (2) 2`
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
         <div class="gux-message">
           <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
         </div>
       </div>
     </div>
@@ -58,6 +68,11 @@ exports[`gux-form-field-radio #render should render component as expected (3) 2`
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -79,6 +94,11 @@ exports[`gux-form-field-radio #render should render component as expected (4) 2`
           <slot name="error"></slot>
         </div>
       </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -98,6 +118,37 @@ exports[`gux-form-field-radio #render should render component as expected (5) 2`
         <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
         <div class="gux-message">
           <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help">
+        <div class="gux-message">
+          <slot name="help"></slot>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`gux-form-field-radio #render should render component as expected (6) 1`] = `"<gux-form-field-radio hydrated=\\"\\"> <input slot=\\"input\\" type=\\"radio\\" name=\\"food-1\\" value=\\"spaghetti\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Spaghetti</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-radio>"`;
+
+exports[`gux-form-field-radio #render should render component as expected (6) 2`] = `
+<div class="gux-form-field-container">
+  <div class="gux-input-label">
+    <div class="gux-input">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-label">
+      <slot name="label"></slot>
+      <div class="gux-form-field-error">
+        <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+        <div class="gux-message">
+          <slot name="error"></slot>
+        </div>
+      </div>
+      <div class="gux-form-field-help gux-show">
+        <div class="gux-message">
+          <slot name="help"></slot>
         </div>
       </div>
     </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/__snapshots__/gux-form-field-radio.spec.ts.snap
@@ -16,6 +16,11 @@ exports[`gux-form-field-radio #render should render component as expected (1) 1`
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -43,6 +48,11 @@ exports[`gux-form-field-radio #render should render component as expected (2) 1`
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -68,6 +78,11 @@ exports[`gux-form-field-radio #render should render component as expected (3) 1`
             <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
             <div class="gux-message">
               <slot name="error"></slot>
+            </div>
+          </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
             </div>
           </div>
         </div>
@@ -100,6 +115,11 @@ exports[`gux-form-field-radio #render should render component as expected (4) 1`
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -127,6 +147,11 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
               <slot name="error"></slot>
             </div>
           </div>
+          <div class="gux-form-field-help">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -137,6 +162,41 @@ exports[`gux-form-field-radio #render should render component as expected (5) 1`
   </label>
   <span id="gux-form-field-error-i" slot="error">
     Error message
+  </span>
+</gux-form-field-radio>
+`;
+
+exports[`gux-form-field-radio #render should render component as expected (6) 1`] = `
+<gux-form-field-radio>
+  <mock:shadow-root>
+    <div class="gux-form-field-container">
+      <div class="gux-input-label">
+        <div class="gux-input">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-label">
+          <slot name="label"></slot>
+          <div class="gux-form-field-error">
+            <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+            <div class="gux-message">
+              <slot name="error"></slot>
+            </div>
+          </div>
+          <div class="gux-form-field-help gux-show">
+            <div class="gux-message">
+              <slot name="help"></slot>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="food-1" slot="input" type="radio" value="spaghetti">
+  <label for="gux-form-field-input-i" slot="label">
+    Spaghetti
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
   </span>
 </gux-form-field-radio>
 `;

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/gux-form-field-radio.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/gux-form-field-radio.e2e.ts
@@ -56,7 +56,12 @@ describe('gux-form-field-radio', () => {
           <label slot="label">Pizza</label>
           <span slot="error">Error message</span>
         </gux-form-field-radio>
-      `
+      `,
+      `<gux-form-field-radio>
+      <input slot="input" type="radio" name="food-1" value="spaghetti" />
+      <label slot="label">Spaghetti</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-radio>`
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newNonrandomE2EPage({ html });

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/gux-form-field-radio.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/tests/gux-form-field-radio.spec.ts
@@ -60,7 +60,12 @@ describe('gux-form-field-radio', () => {
           <label slot="label">Pizza</label>
           <span slot="error">Error message</span>
         </gux-form-field-radio>
-      `
+      `,
+      `<gux-form-field-radio>
+      <input slot="input" type="radio" name="food-1" value="spaghetti" />
+      <label slot="label">Spaghetti</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-radio>`
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/example.html
@@ -107,6 +107,16 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-range>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-range>
+      <input slot="input" type="range" name="e-1" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-range>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.less
@@ -11,10 +11,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 // Variables part
 @range-active: @gux-blue-60;

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.tsx
@@ -9,28 +9,32 @@ import {
   State
 } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
-  hasErrorSlot,
   getComputedLabelPosition,
   validateFormIds
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-range.less',
@@ -72,6 +76,9 @@ export class GuxFormField {
   private hasError: boolean = false;
 
   @State()
+  private hasHelp: boolean = false;
+
+  @State()
   private value: string;
 
   @State()
@@ -102,14 +109,16 @@ export class GuxFormField {
 
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -141,9 +150,12 @@ export class GuxFormField {
           </GuxFormFieldLabel>
           <div class="gux-input-and-error-container">
             {this.renderRangeInput()}
-            <GuxFormFieldError hasError={this.hasError}>
+            <GuxFormFieldError show={this.hasError}>
               <slot name="error" />
             </GuxFormFieldError>
+            <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+              <slot name="help" />
+            </GuxFormFieldHelp>
           </div>
         </GuxFormFieldContainer>
       </Host>

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/readme.md
@@ -19,6 +19,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/example.html
@@ -61,6 +61,16 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-search>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-search>
+      <input slot="input" type="search" name="e-1" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-search>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.tsx
@@ -1,29 +1,33 @@
 import { Component, Element, h, JSX, Prop, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
   clearInput,
-  hasErrorSlot,
   hasContent,
   getComputedLabelPosition,
   validateFormIds
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-search.less',
@@ -60,16 +64,21 @@ export class GuxFormFieldSearch {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -110,9 +119,12 @@ export class GuxFormFieldSearch {
               )}
             </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/readme.md
@@ -17,6 +17,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.e2e.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-search #render help should render component as expected 1`] = `"<gux-form-field-search hydrated=\\"\\"> <input slot=\\"input\\" type=\\"search\\" name=\\"e-1\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-search>"`;
+
+exports[`gux-form-field-search #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input">
+      <div class="gux-input-container">
+        <gux-icon hydrated="" icon-name="search"></gux-icon>
+        <slot name="input"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`gux-form-field-search #render input attributes should render component as expected (1) 1`] = `"<gux-form-field-search lang=\\"en\\" hydrated=\\"\\"> <input slot=\\"input\\" type=\\"search\\" value=\\"Sample search\\" id=\\"gux-form-field-input-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Label</label> </gux-form-field-search>"`;
 
 exports[`gux-form-field-search #render input attributes should render component as expected (1) 2`] = `
@@ -19,6 +48,11 @@ exports[`gux-form-field-search #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -43,6 +77,11 @@ exports[`gux-form-field-search #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -70,6 +109,11 @@ exports[`gux-form-field-search #render input attributes should render component 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -93,6 +137,11 @@ exports[`gux-form-field-search #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -120,6 +169,11 @@ exports[`gux-form-field-search #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -145,6 +199,11 @@ exports[`gux-form-field-search #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -168,6 +227,11 @@ exports[`gux-form-field-search #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/tests/__snapshots__/gux-form-field-search.spec.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-search #render help should render component as expected 1`] = `
+<gux-form-field-search>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <div class="gux-input-container">
+            <gux-icon decorative="" icon-name="search"></gux-icon>
+            <slot name="input"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="e-1" slot="input" type="search">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-search>
+`;
+
 exports[`gux-form-field-search #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-search>
   <mock:shadow-root>
@@ -19,6 +57,11 @@ exports[`gux-form-field-search #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -49,6 +92,11 @@ exports[`gux-form-field-search #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -82,6 +130,11 @@ exports[`gux-form-field-search #render input attributes should render component 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -111,6 +164,11 @@ exports[`gux-form-field-search #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -144,6 +202,11 @@ exports[`gux-form-field-search #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -175,6 +238,11 @@ exports[`gux-form-field-search #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -204,6 +272,11 @@ exports[`gux-form-field-search #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.e2e.ts
@@ -84,5 +84,32 @@ describe('gux-form-field-search', () => {
         });
       });
     });
+
+    describe('help', () => {
+      const html = `
+      <gux-form-field-search>
+      <input slot="input" type="search" name="e-1" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-search>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-search');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/tests/gux-form-field-search.spec.ts
@@ -65,5 +65,20 @@ describe('gux-form-field-search', () => {
         });
       });
     });
+
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-search>
+        <input slot="input" type="search" name="e-1" />
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-search>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/example.html
@@ -97,6 +97,20 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-select>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-select>
+      <select slot="input" name="e-1">
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+      </select>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-select>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.tsx
@@ -1,27 +1,31 @@
 import { Component, Element, h, JSX, Prop, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
-  hasErrorSlot,
   getComputedLabelPosition,
   validateFormIds
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-select.less',
@@ -52,16 +56,21 @@ export class GuxFormFieldSelect {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -97,9 +106,12 @@ export class GuxFormFieldSelect {
               <gux-icon icon-name="ic-dropdown-arrow" decorative></gux-icon>
             </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/readme.md
@@ -17,6 +17,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.e2e.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-select #render help should render component as expected 1`] = `"<gux-form-field-select hydrated=\\"\\"> <select slot=\\"input\\" name=\\"e-1\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <option value=\\"option1\\">Option 1</option> <option value=\\"option2\\">Option 2</option> <option value=\\"option3\\">Option 3</option> </select> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-select>"`;
+
+exports[`gux-form-field-select #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input">
+      <div class="gux-input-container">
+        <slot name="input"></slot>
+        <gux-icon hydrated="" icon-name="ic-dropdown-arrow"></gux-icon>
+      </div>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`gux-form-field-select #render input attributes should render component as expected (1) 1`] = `"<gux-form-field-select hydrated=\\"\\"> <select slot=\\"input\\" name=\\"lp-1\\" id=\\"gux-form-field-input-i\\"> <option value=\\"option1\\">Option 1</option> <option value=\\"option2\\">Option 2</option> <option value=\\"option3\\">Option 3</option> </select> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> </gux-form-field-select>"`;
 
 exports[`gux-form-field-select #render input attributes should render component as expected (1) 2`] = `
@@ -18,6 +47,11 @@ exports[`gux-form-field-select #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -44,6 +78,11 @@ exports[`gux-form-field-select #render input attributes should render component 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -66,6 +105,11 @@ exports[`gux-form-field-select #render input attributes should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -92,6 +136,11 @@ exports[`gux-form-field-select #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -114,6 +163,11 @@ exports[`gux-form-field-select #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -140,6 +194,11 @@ exports[`gux-form-field-select #render label-position should render component as
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -162,6 +221,11 @@ exports[`gux-form-field-select #render label-position should render component as
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/tests/__snapshots__/gux-form-field-select.spec.ts.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-select #render help should render component as expected 1`] = `
+<gux-form-field-select>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <div class="gux-input-container">
+            <slot name="input"></slot>
+            <gux-icon decorative="" icon-name="ic-dropdown-arrow"></gux-icon>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <select aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="e-1" slot="input">
+    <option value="option1">
+      Option 1
+    </option>
+    <option value="option2">
+      Option 2
+    </option>
+    <option value="option3">
+      Option 3
+    </option>
+  </select>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-select>
+`;
+
 exports[`gux-form-field-select #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-select>
   <mock:shadow-root>
@@ -18,6 +66,11 @@ exports[`gux-form-field-select #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -60,6 +113,11 @@ exports[`gux-form-field-select #render input attributes should render component 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -98,6 +156,11 @@ exports[`gux-form-field-select #render input attributes should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -140,6 +203,11 @@ exports[`gux-form-field-select #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -178,6 +246,11 @@ exports[`gux-form-field-select #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -220,6 +293,11 @@ exports[`gux-form-field-select #render label-position should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -258,6 +336,11 @@ exports[`gux-form-field-select #render label-position should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.e2e.ts
@@ -92,5 +92,35 @@ describe('gux-form-field-select', () => {
         });
       });
     });
+    describe('help', () => {
+      const html = `
+      <gux-form-field-select>
+      <select slot="input" name="e-1">
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+      </select>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+      </gux-form-field-select>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-select');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/tests/gux-form-field-select.spec.ts
@@ -76,5 +76,23 @@ describe('gux-form-field-select', () => {
         });
       });
     });
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-select>
+        <select slot="input" name="e-1">
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </select>
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-select>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/example.html
@@ -146,6 +146,16 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-text-like>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-text-like>
+      <input slot="input" type="text" name="e-1" />
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-text-like>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;
@@ -42,7 +45,8 @@
   }
 }
 
-::slotted(span) {
+slot[name='prefix'],
+slot[name='suffix'] {
   color: @gux-black-50;
   white-space: nowrap;
 }

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
@@ -9,26 +9,29 @@ import {
   State
 } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
   clearInput,
-  hasErrorSlot,
   hasContent,
   getComputedLabelPosition,
   validateFormIds,
   setSlotAriaDescribedby
 } from '../../gux-form-field.service';
+import { trackComponent } from '../../../../../usage-tracking';
 
 /**
  * @slot input - Required slot for input tag
@@ -36,6 +39,7 @@ import {
  * @slot prefix - Optional slot for prefix
  * @slot suffix - Optional slot for suffix
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-text-like.less',
@@ -78,16 +82,21 @@ export class GuxFormFieldTextLike {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   @Method()
   async guxForceUpdate(): Promise<void> {
     this.hasContent = hasContent(this.input);
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     forceUpdate(this.root);
   }
@@ -96,7 +105,8 @@ export class GuxFormFieldTextLike {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
     this.hasPrefix = Boolean(this.root.querySelector('[slot="prefix"]'));
     this.hasSuffix = Boolean(this.root.querySelector('[slot="suffix"]'));
 
@@ -150,9 +160,12 @@ export class GuxFormFieldTextLike {
               )}
             </div>
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/readme.md
@@ -31,6 +31,7 @@ Type: `Promise<void>`
 | Slot       | Description                     |
 | ---------- | ------------------------------- |
 | `"error"`  | Optional slot for error message |
+| `"help"`   | Optional slot for help message  |
 | `"input"`  | Required slot for input tag     |
 | `"label"`  | Required slot for label tag     |
 | `"prefix"` | Optional slot for prefix        |

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.e2e.ts.snap
@@ -21,6 +21,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -45,6 +50,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -73,6 +83,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -96,6 +111,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -123,6 +143,41 @@ exports[`gux-form-field-text-like #render clearable should render component as e
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`gux-form-field-text-like #render help should render component as expected 1`] = `"<gux-form-field-text-like hydrated=\\"\\"> <input slot=\\"input\\" type=\\"text\\" name=\\"e-1\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-text-like>"`;
+
+exports[`gux-form-field-text-like #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input">
+      <div class="gux-input-container">
+        <slot name="prefix"></slot>
+        <slot name="input"></slot>
+        <slot name="suffix"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -146,6 +201,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -173,6 +233,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -196,6 +261,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -223,6 +293,11 @@ exports[`gux-form-field-text-like #render label-position should render component
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -246,6 +321,11 @@ exports[`gux-form-field-text-like #render label-position should render component
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -273,6 +353,11 @@ exports[`gux-form-field-text-like #render label-position should render component
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -296,6 +381,11 @@ exports[`gux-form-field-text-like #render label-position should render component
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -323,6 +413,11 @@ exports[`gux-form-field-text-like #render prefix should render component as expe
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -346,6 +441,11 @@ exports[`gux-form-field-text-like #render suffix should render component as expe
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -373,6 +473,11 @@ exports[`gux-form-field-text-like input attributes should render component as ex
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -398,6 +503,11 @@ exports[`gux-form-field-text-like input attributes should render component as ex
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -421,6 +531,11 @@ exports[`gux-form-field-text-like input attributes should render component as ex
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/__snapshots__/gux-form-field-text-like.spec.ts.snap
@@ -21,6 +21,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -51,6 +56,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -85,6 +95,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -114,6 +129,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -147,6 +167,11 @@ exports[`gux-form-field-text-like #render clearable should render component as e
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -154,6 +179,45 @@ exports[`gux-form-field-text-like #render clearable should render component as e
   <label for="gux-form-field-input-i" slot="label">
     Label
   </label>
+</gux-form-field-text-like>
+`;
+
+exports[`gux-form-field-text-like #render help should render component as expected 1`] = `
+<gux-form-field-text-like>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <div class="gux-input-container">
+            <slot name="prefix"></slot>
+            <slot name="input"></slot>
+            <slot name="suffix"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <input aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="e-1" slot="input" type="text">
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
 </gux-form-field-text-like>
 `;
 
@@ -176,6 +240,11 @@ exports[`gux-form-field-text-like #render input attributes should render compone
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -209,6 +278,11 @@ exports[`gux-form-field-text-like #render input attributes should render compone
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -238,6 +312,11 @@ exports[`gux-form-field-text-like #render input attributes should render compone
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -271,6 +350,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -300,6 +384,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -333,6 +422,11 @@ exports[`gux-form-field-text-like #render input type attribute should render com
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -362,6 +456,11 @@ exports[`gux-form-field-text-like #render label-position should render component
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -395,6 +494,11 @@ exports[`gux-form-field-text-like #render label-position should render component
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -424,6 +528,11 @@ exports[`gux-form-field-text-like #render label-position should render component
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -457,6 +566,11 @@ exports[`gux-form-field-text-like #render label-position should render component
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -486,6 +600,11 @@ exports[`gux-form-field-text-like #render prefix should render component as expe
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -520,6 +639,11 @@ exports[`gux-form-field-text-like #render suffix should render component as expe
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.e2e.ts
@@ -145,6 +145,33 @@ describe('gux-form-field-text-like', () => {
       });
     });
 
+    describe('help', () => {
+      const html = `
+        <gux-form-field-text-like>
+        <input slot="input" type="text" name="e-1" />
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-text-like>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-text-like');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
+
     describe('input type attribute', () => {
       ['email', 'password', 'text'].forEach((inputTypeAttribute, index) => {
         const html = `

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/tests/gux-form-field-text-like.spec.ts
@@ -81,6 +81,21 @@ describe('gux-form-field-text-like', () => {
       });
     });
 
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+          <gux-form-field-text-like>
+          <input slot="input" type="text" name="e-1" />
+          <label slot="label">Default</label>
+          <span slot="help">This is a help message</span>
+        </gux-form-field-text-like>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+
     describe('label-position', () => {
       [
         '',

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/example.html
@@ -89,6 +89,16 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-textarea>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+
+    <gux-form-field-textarea>
+      <textarea slot="input" name="textarea"></textarea>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-textarea>
+  </fieldset>
 </form>
 
 <h2>gux-form-field-legacy examples for comparison</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.less
@@ -9,10 +9,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-label/gux-form-field-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
+.GuxFormFieldHelpStyle();
 
 :host {
   display: block;

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.tsx
@@ -1,28 +1,32 @@
 import { Component, Element, h, JSX, Prop, State } from '@stencil/core';
 
-import { calculateInputDisabledState } from '../../../../../utils/dom/calculate-input-disabled-state';
-import { onInputDisabledStateChange } from '../../../../../utils/dom/on-input-disabled-state-change';
-import { OnMutation } from '../../../../../utils/decorator/on-mutation';
-import { onRequiredChange } from '../../../../../utils/dom/on-attribute-change';
-import { preventBrowserValidationStyling } from '../../../../../utils/dom/prevent-browser-validation-styling';
-import { trackComponent } from '../../../../../usage-tracking';
+import { calculateInputDisabledState } from '@utils/dom/calculate-input-disabled-state';
+import { onInputDisabledStateChange } from '@utils/dom/on-input-disabled-state-change';
+import { OnMutation } from '@utils/decorator/on-mutation';
+import { onRequiredChange } from '@utils/dom/on-attribute-change';
+import { preventBrowserValidationStyling } from '@utils/dom/prevent-browser-validation-styling';
+import { hasSlot } from '@utils/dom/has-slot';
 
-import { GuxFormFieldContainer } from '../../functional-components/gux-form-field-container/gux-form-field-container';
-import { GuxFormFieldError } from '../../functional-components/gux-form-field-error/gux-form-field-error';
-import { GuxFormFieldLabel } from '../../functional-components/gux-form-field-label/gux-form-field-label';
+import {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer
+} from '../../functional-components/functional-components';
 
 import { GuxFormFieldLabelPosition } from '../../gux-form-field.types';
 import {
-  hasErrorSlot,
   getComputedLabelPosition,
   validateFormIds
 } from '../../gux-form-field.service';
-
 import { GuxFormFieldTextAreaResize } from './gux-form-field-textarea.types';
+import { trackComponent } from '../../../../../usage-tracking';
+
 /**
  * @slot input - Required slot for input tag
  * @slot label - Required slot for label tag
  * @slot error - Optional slot for error message
+ * @slot help - Optional slot for help message
  */
 @Component({
   styleUrl: 'gux-form-field-textarea.less',
@@ -57,16 +61,21 @@ export class GuxFormFieldTextarea {
   @State()
   private hasError: boolean = false;
 
+  @State()
+  private hasHelp: boolean = false;
+
   @OnMutation({ childList: true, subtree: true })
   onMutation(): void {
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
   }
 
   componentWillLoad(): void {
     this.setInput();
     this.setLabel();
 
-    this.hasError = hasErrorSlot(this.root);
+    this.hasError = hasSlot(this.root, 'error');
+    this.hasHelp = hasSlot(this.root, 'help');
 
     trackComponent(this.root, { variant: this.variant });
   }
@@ -101,9 +110,12 @@ export class GuxFormFieldTextarea {
           >
             <slot name="input" />
           </div>
-          <GuxFormFieldError hasError={this.hasError}>
+          <GuxFormFieldError show={this.hasError}>
             <slot name="error" />
           </GuxFormFieldError>
+          <GuxFormFieldHelp show={!this.hasError && this.hasHelp}>
+            <slot name="help" />
+          </GuxFormFieldHelp>
         </div>
       </GuxFormFieldContainer>
     ) as JSX.Element;

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/readme.md
@@ -18,6 +18,7 @@
 | Slot      | Description                     |
 | --------- | ------------------------------- |
 | `"error"` | Optional slot for error message |
+| `"help"`  | Optional slot for help message  |
 | `"input"` | Required slot for input tag     |
 | `"label"` | Required slot for label tag     |
 

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.e2e.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-textarea #render help should render component as expected 1`] = `"<gux-form-field-textarea hydrated=\\"\\"> <textarea slot=\\"input\\" name=\\"textarea\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\"></textarea> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Default</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-textarea>"`;
+
+exports[`gux-form-field-textarea #render help should render component as expected 2`] = `
+<div class="gux-above gux-form-field-container">
+  <div class="gux-above gux-form-field-label">
+    <slot name="label"></slot>
+  </div>
+  <div class="gux-input-and-error-container">
+    <div class="gux-input gux-resize-undefined">
+      <slot name="input"></slot>
+    </div>
+    <div class="gux-form-field-error">
+      <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
+      <div class="gux-message">
+        <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help gux-show">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`gux-form-field-textarea #render input attributes should render component as expected (1) 1`] = `"<gux-form-field-textarea hydrated=\\"\\"> <textarea slot=\\"input\\" id=\\"gux-form-field-input-i\\"></textarea> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Label</label> </gux-form-field-textarea>"`;
 
 exports[`gux-form-field-textarea #render input attributes should render component as expected (1) 2`] = `
@@ -15,6 +41,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -38,6 +69,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -57,6 +93,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -80,6 +121,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -99,6 +145,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -122,6 +173,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -141,6 +197,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -164,6 +225,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -183,6 +249,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>
@@ -206,6 +277,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
         <slot name="error"></slot>
       </div>
     </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -225,6 +301,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
       <gux-icon hydrated="" icon-name="alert-warning-octogon"></gux-icon>
       <div class="gux-message">
         <slot name="error"></slot>
+      </div>
+    </div>
+    <div class="gux-form-field-help">
+      <div class="gux-message">
+        <slot name="help"></slot>
       </div>
     </div>
   </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/__snapshots__/gux-form-field-textarea.spec.ts.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-textarea #render help should render component as expected 1`] = `
+<gux-form-field-textarea>
+  <mock:shadow-root>
+    <div class="gux-above gux-form-field-container">
+      <div class="gux-above gux-form-field-label">
+        <slot name="label"></slot>
+      </div>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input gux-resize-undefined">
+          <slot name="input"></slot>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root><textarea aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" name="textarea" slot="input"></textarea>
+  <label for="gux-form-field-input-i" slot="label">
+    Default
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-textarea>
+`;
+
 exports[`gux-form-field-textarea #render input attributes should render component as expected (1) 1`] = `
 <gux-form-field-textarea>
   <mock:shadow-root>
@@ -15,6 +49,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -43,6 +82,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root><textarea disabled="" id="gux-form-field-input-i" slot="input"></textarea>
@@ -67,6 +111,11 @@ exports[`gux-form-field-textarea #render input attributes should render componen
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -95,6 +144,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root><textarea id="gux-form-field-input-i" slot="input"></textarea>
@@ -119,6 +173,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -147,6 +206,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root><textarea id="gux-form-field-input-i" slot="input"></textarea>
@@ -171,6 +235,11 @@ exports[`gux-form-field-textarea #render label-position should render component 
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -199,6 +268,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root><textarea id="gux-form-field-input-i" slot="input"></textarea>
@@ -223,6 +297,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -251,6 +330,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </div>
   </mock:shadow-root><textarea id="gux-form-field-input-i" slot="input"></textarea>
@@ -275,6 +359,11 @@ exports[`gux-form-field-textarea #render resize should render component as expec
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.e2e.ts
@@ -114,5 +114,31 @@ describe('gux-form-field-textarea', () => {
         });
       });
     });
+    describe('help', () => {
+      const html = `
+      <gux-form-field-textarea>
+      <textarea slot="input" name="textarea"></textarea>
+      <label slot="label">Default</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-textarea>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-textarea');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/tests/gux-form-field-textarea.spec.ts
@@ -83,5 +83,20 @@ describe('gux-form-field-textarea', () => {
         });
       });
     });
+
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-textarea>
+        <textarea slot="input" name="textarea"></textarea>
+        <label slot="label">Default</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-textarea>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/example.html
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/example.html
@@ -73,6 +73,15 @@
       <span slot="error">This is an error message</span>
     </gux-form-field-time-picker>
   </fieldset>
+
+  <fieldset>
+    <legend>Help</legend>
+    <gux-form-field-time-picker>
+      <gux-time-picker-beta value="09:00"></gux-time-picker-beta>
+      <label slot="label">Select Time</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-time-picker>
+  </fieldset>
 </form>
 
 <h2>Languages</h2>

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/gux-form-field-time-picker.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/gux-form-field-time-picker.less
@@ -10,10 +10,13 @@
   '../../functional-components/gux-form-field-error/gux-form-field-error.less';
 @import (reference)
   '../../functional-components/gux-form-field-legend-label/gux-form-field-legend-label.less';
+@import (reference)
+  '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
 .GuxFormFieldFieldsetContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLegendLabelStyle();
+.GuxFormFieldHelpStyle();
 
 ::slotted(label) {
   .gux-label();

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/readme.md
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/readme.md
@@ -14,11 +14,12 @@
 
 ## Slots
 
-| Slot      | Description                                |
-| --------- | ------------------------------------------ |
-|           | Required slot for gux-time-picker-beta tag |
-| `"error"` | Optional slot for error message            |
-| `"label"` | Required slot for label tag                |
+| Slot                                           | Description                     |
+| ---------------------------------------------- | ------------------------------- |
+| `"Required slot for gux-time-picker-beta tag"` |                                 |
+| `"error"`                                      | Optional slot for error message |
+| `"help"`                                       | Optional slot for help message  |
+| `"label"`                                      | Required slot for label tag     |
 
 
 ## Dependencies

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.e2e.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.e2e.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-time-picker #render help should render component as expected 1`] = `"<gux-form-field-time-picker hydrated=\\"\\"> <gux-time-picker-beta value=\\"09:00\\" id=\\"gux-form-field-input-i\\" aria-describedby=\\"gux-form-field-help-i\\" hydrated=\\"\\"></gux-time-picker-beta> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Select Time</label> <span slot=\\"help\\" id=\\"gux-form-field-help-i\\">This is a help message</span> </gux-form-field-time-picker>"`;
+
+exports[`gux-form-field-time-picker #render help should render component as expected 2`] = `null`;
+
 exports[`gux-form-field-time-picker #render interval should render component as expected (1) 1`] = `"<gux-form-field-time-picker hydrated=\\"\\"> <gux-time-picker-beta value=\\"07:00\\" interval=\\"15\\" id=\\"gux-form-field-input-i\\" hydrated=\\"\\"></gux-time-picker-beta> <label slot=\\"label\\" for=\\"gux-form-field-input-i\\">Label</label> </gux-form-field-time-picker>"`;
 
 exports[`gux-form-field-time-picker #render interval should render component as expected (1) 2`] = `null`;

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.spec.ts.snap
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/__snapshots__/gux-form-field-time-picker.spec.ts.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gux-form-field-time-picker #render help should render component as expected 1`] = `
+<gux-form-field-time-picker>
+  <mock:shadow-root>
+    <fieldset class="gux-above gux-form-field-fieldset-container">
+      <legend class="gux-above gux-form-field-legend-label">
+        <slot name="label"></slot>
+        <gux-screen-reader-beta>
+          <mock:shadow-root>
+            <span class="gux-sr-only">
+              <slot></slot>
+            </span>
+          </mock:shadow-root>
+          Required
+        </gux-screen-reader-beta>
+      </legend>
+      <div class="gux-input-and-error-container">
+        <div class="gux-input">
+          <div class="gux-time-picker-container">
+            <slot></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-error">
+          <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
+          <div class="gux-message">
+            <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help gux-show">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </mock:shadow-root>
+  <gux-time-picker-beta aria-describedby="gux-form-field-help-i" id="gux-form-field-input-i" value="09:00"></gux-time-picker-beta>
+  <label for="gux-form-field-input-i" slot="label">
+    Select Time
+  </label>
+  <span id="gux-form-field-help-i" slot="help">
+    This is a help message
+  </span>
+</gux-form-field-time-picker>
+`;
+
 exports[`gux-form-field-time-picker #render intervals should render component as expected (1) 1`] = `
 <gux-form-field-time-picker>
   <mock:shadow-root>
@@ -25,6 +70,11 @@ exports[`gux-form-field-time-picker #render intervals should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -64,6 +114,11 @@ exports[`gux-form-field-time-picker #render intervals should render component as
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </fieldset>
   </mock:shadow-root>
@@ -99,6 +154,11 @@ exports[`gux-form-field-time-picker #render intervals should render component as
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -138,6 +198,11 @@ exports[`gux-form-field-time-picker #render label-position should render compone
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </fieldset>
   </mock:shadow-root>
@@ -173,6 +238,11 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>
@@ -212,6 +282,11 @@ exports[`gux-form-field-time-picker #render label-position should render compone
             <slot name="error"></slot>
           </div>
         </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
+          </div>
+        </div>
       </div>
     </fieldset>
   </mock:shadow-root>
@@ -247,6 +322,11 @@ exports[`gux-form-field-time-picker #render label-position should render compone
           <gux-icon decorative="" icon-name="alert-warning-octogon"></gux-icon>
           <div class="gux-message">
             <slot name="error"></slot>
+          </div>
+        </div>
+        <div class="gux-form-field-help">
+          <div class="gux-message">
+            <slot name="help"></slot>
           </div>
         </div>
       </div>

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/gux-form-field-time-picker.e2e.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/gux-form-field-time-picker.e2e.ts
@@ -86,5 +86,32 @@ describe('gux-form-field-time-picker', () => {
         }
       );
     });
+
+    describe('help', () => {
+      const html = `
+      <gux-form-field-time-picker>
+      <gux-time-picker-beta value="09:00"></gux-time-picker-beta>
+      <label slot="label">Select Time</label>
+      <span slot="help">This is a help message</span>
+    </gux-form-field-time-picker>
+      `;
+
+      it('should render component as expected', async () => {
+        const page = await newNonrandomE2EPage({ html });
+        const element = await page.find('gux-form-field-time-picker');
+        const elementShadowDom = await element.find(
+          'pierce/.gux-form-field-container'
+        );
+
+        expect(element.outerHTML).toMatchSnapshot();
+        expect(elementShadowDom).toMatchSnapshot();
+      });
+
+      it('should be accessible', async () => {
+        const page = await newSparkE2EPage({ html });
+
+        await a11yCheck(page, axeExclusions);
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/gux-form-field-time-picker.spec.ts
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/tests/gux-form-field-time-picker.spec.ts
@@ -68,5 +68,20 @@ describe('gux-form-field-time-picker', () => {
         }
       );
     });
+
+    describe('help', () => {
+      it('should render component as expected', async () => {
+        const html = `
+        <gux-form-field-time-picker>
+        <gux-time-picker-beta value="09:00"></gux-time-picker-beta>
+        <label slot="label">Select Time</label>
+        <span slot="help">This is a help message</span>
+      </gux-form-field-time-picker>
+        `;
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/stable/gux-form-field/functional-components/functional-components.ts
+++ b/src/components/stable/gux-form-field/functional-components/functional-components.ts
@@ -1,0 +1,15 @@
+import { GuxFormFieldHelp } from './gux-form-field-help/gux-form-field-help';
+import { GuxFormFieldError } from './gux-form-field-error/gux-form-field-error';
+import { GuxFormFieldLabel } from './gux-form-field-label/gux-form-field-label';
+import { GuxFormFieldContainer } from './gux-form-field-container/gux-form-field-container';
+import { GuxFormFieldLegendLabel } from './gux-form-field-legend-label/gux-form-field-legend-label';
+import { GuxFormFieldFieldsetContainer } from './gux-form-field-fieldset-container/gux-form-field-fieldset-container';
+
+export {
+  GuxFormFieldHelp,
+  GuxFormFieldError,
+  GuxFormFieldLabel,
+  GuxFormFieldContainer,
+  GuxFormFieldLegendLabel,
+  GuxFormFieldFieldsetContainer
+};

--- a/src/components/stable/gux-form-field/functional-components/gux-form-field-help/gux-form-field-help.less
+++ b/src/components/stable/gux-form-field/functional-components/gux-form-field-help/gux-form-field-help.less
@@ -1,0 +1,28 @@
+@import (reference) '../../../../../style/color-palette.less';
+@import (reference) '../../../../../style/spacing.less';
+/* stylelint-disable-next-line selector-class-pattern */
+.GuxFormFieldHelpStyle {
+  .gux-form-field-help {
+    display: none;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-content: stretch;
+    align-items: flex-start;
+    justify-content: flex-start;
+    margin: @gux-spacing-2xs 0;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 20px;
+    color: @gux-black-100;
+
+    &.gux-show {
+      display: flex;
+    }
+
+    .gux-message {
+      flex: 0 1 auto;
+      align-self: none;
+      order: 0;
+    }
+  }
+}

--- a/src/components/stable/gux-form-field/functional-components/gux-form-field-help/gux-form-field-help.tsx
+++ b/src/components/stable/gux-form-field/functional-components/gux-form-field-help/gux-form-field-help.tsx
@@ -1,21 +1,20 @@
 import { FunctionalComponent, h, VNode } from '@stencil/core';
 
-interface GuxFormFieldErrorProps {
+interface GuxFormFieldHelpProps {
   show: boolean;
 }
 
-export const GuxFormFieldError: FunctionalComponent<GuxFormFieldErrorProps> = (
+export const GuxFormFieldHelp: FunctionalComponent<GuxFormFieldHelpProps> = (
   { show },
   children
 ): VNode => {
   return (
     <div
       class={{
-        'gux-form-field-error': true,
+        'gux-form-field-help': true,
         'gux-show': show
       }}
     >
-      <gux-icon icon-name="alert-warning-octogon" decorative></gux-icon>
       <div class="gux-message">{children}</div>
     </div>
   ) as VNode;

--- a/src/components/stable/gux-form-field/gux-form-field.service.ts
+++ b/src/components/stable/gux-form-field/gux-form-field.service.ts
@@ -1,19 +1,12 @@
 import { randomHTMLId } from '../../../utils/dom/random-html-id';
 import { logError } from '../../../utils/error/log-error';
 import setInputValue from '../../../utils/dom/set-input-value';
+import { hasSlot } from '@utils/dom/has-slot';
 
 import { GuxFormFieldLabelPosition } from './gux-form-field.types';
 
 export function clearInput(input: HTMLInputElement): void {
   setInputValue(input, '', true);
-}
-
-export function hasErrorSlot(root: HTMLElement): boolean {
-  return Boolean(root.querySelector('[slot="error"]'));
-}
-
-export function getErrorSlotTextContent(root: HTMLElement): string {
-  return root.querySelector('[slot="error"]')?.textContent;
 }
 
 export function hasContent(
@@ -81,7 +74,7 @@ export function validateFormIds(
     );
   }
 
-  if (hasErrorSlot(root)) {
+  if (hasSlot(root, 'error')) {
     const error = root.querySelector('[slot="error"]');
     const errorId = randomHTMLId('gux-form-field-error');
     const describedByIds =
@@ -101,6 +94,29 @@ export function validateFormIds(
         .getAttribute('aria-describedby')
         ?.split(' ')
         .filter(id => !id.startsWith(`gux-form-field-error`)) || [];
+    input.setAttribute('aria-describedby', describedByIds.join(' '));
+  }
+
+  if (hasSlot(root, 'help')) {
+    const help = root.querySelector('[slot="help"]');
+    const helpId = randomHTMLId('gux-form-field-help');
+    const describedByIds =
+      input
+        .getAttribute('aria-describedby')
+        ?.split(' ')
+        .filter(id => !id.startsWith(`gux-form-field-help`)) || [];
+
+    help.setAttribute('id', helpId);
+    describedByIds.push(helpId);
+
+    describedByIds &&
+      input.setAttribute('aria-describedby', describedByIds.join(' '));
+  } else if (input.getAttribute('aria-describedby')) {
+    const describedByIds =
+      input
+        .getAttribute('aria-describedby')
+        ?.split(' ')
+        .filter(id => !id.startsWith(`gux-form-field-help`)) || [];
     input.setAttribute('aria-describedby', describedByIds.join(' '));
   }
 }

--- a/src/utils/dom/get-slot-text-content.ts
+++ b/src/utils/dom/get-slot-text-content.ts
@@ -1,0 +1,6 @@
+export function getSlotTextContent(
+  root: HTMLElement,
+  slotName: string
+): string {
+  return root.querySelector(`[slot=${slotName}]`)?.textContent;
+}


### PR DESCRIPTION

**Related Task** : https://inindca.atlassian.net/browse/COMUI-1162

This is currently only implemented in **form-field-text-like.** Once approved I will implement to the rest of form-field components.

**Description :** 
Add a slot to form field components that can be used similar to how the error slot works but that is meant for non-error informational text. This would provide a way to add contextual information about the field without resorting to less accessible things like tooltips.

**Acceptance Criteria:**

Allow the display of help text on inputs.

As help text & error messages are displayed in the same position, error messages should take precedence over help text if both are present.
