### PR TITLE
feat(dropdown-multi): addition of collapsed and expanded events

### DIFF
--- a/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.tsx
+++ b/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.tsx
@@ -8,7 +8,9 @@ import {
   Method,
   Prop,
   State,
-  Watch
+  Watch,
+  Event,
+  EventEmitter
 } from '@stencil/core';
 
 import { OnClickOutside } from '../../../utils/decorator/on-click-outside';
@@ -61,6 +63,36 @@ export class GuxDropdownMulti {
 
   @State()
   private filter: string = '';
+
+  /**
+   * This event will run when the dropdown-multi transitions to an expanded state.
+   */
+  @Event()
+  guxexpanded: EventEmitter<void>;
+
+  /**
+   * This event will run when the dropdown-multi transitions to a collapsed state.
+   */
+  @Event()
+  guxcollapsed: EventEmitter<void>;
+
+  /**
+   * Listens for expanded event emitted by gux-popup.
+   */
+  @Listen('internalexpanded')
+  onInternalExpanded(event: CustomEvent): void {
+    event.stopPropagation();
+    this.guxexpanded.emit();
+  }
+
+  /**
+   * Listens for collapsed event emitted by gux-popup.
+   */
+  @Listen('internalcollapsed')
+  onInternalCollapsed(event: CustomEvent): void {
+    event.stopPropagation();
+    this.guxcollapsed.emit();
+  }
 
   @Watch('expanded')
   focusSelectedItemAfterRender(expanded: boolean) {

--- a/src/components/beta/gux-dropdown-multi/readme.md
+++ b/src/components/beta/gux-dropdown-multi/readme.md
@@ -15,6 +15,14 @@
 | `value`       | `value`       |             | `string`  | `undefined` |
 
 
+## Events
+
+| Event          | Description                                                                   | Type                |
+| -------------- | ----------------------------------------------------------------------------- | ------------------- |
+| `guxcollapsed` | This event will run when the dropdown-multi transitions to a collapsed state. | `CustomEvent<void>` |
+| `guxexpanded`  | This event will run when the dropdown-multi transitions to an expanded state. | `CustomEvent<void>` |
+
+
 ## Methods
 
 ### `getSelectedValues() => Promise<string[]>`

--- a/src/components/stable/gux-popup/gux-popup.tsx
+++ b/src/components/stable/gux-popup/gux-popup.tsx
@@ -1,4 +1,12 @@
-import { Component, h, JSX, Prop, Watch } from '@stencil/core';
+import {
+  Component,
+  h,
+  JSX,
+  Prop,
+  Watch,
+  Event,
+  EventEmitter
+} from '@stencil/core';
 
 import { createPopper, Instance } from '@popperjs/core';
 
@@ -22,10 +30,25 @@ export class GuxPopup {
   @Prop()
   disabled: boolean = false;
 
+  /**
+   * This event will run when the popup transitions to an expanded state.
+   */
+  @Event()
+  internalexpanded: EventEmitter<void>;
+
+  /**
+   * This event will run when the popup transitions to a collapsed state.
+   */
+  @Event()
+  internalcollapsed: EventEmitter<void>;
+
   @Watch('expanded')
   onExpandedChange(expanded: boolean) {
     if (expanded) {
       this.popperInstance.forceUpdate();
+      this.internalexpanded.emit();
+    } else {
+      this.internalcollapsed.emit();
     }
   }
 

--- a/src/components/stable/gux-popup/readme.md
+++ b/src/components/stable/gux-popup/readme.md
@@ -13,6 +13,14 @@
 | `expanded` | `expanded` |             | `boolean` | `false` |
 
 
+## Events
+
+| Event               | Description                                                          | Type                |
+| ------------------- | -------------------------------------------------------------------- | ------------------- |
+| `internalcollapsed` | This event will run when the popup transitions to a collapsed state. | `CustomEvent<void>` |
+| `internalexpanded`  | This event will run when the popup transitions to an expanded state. | `CustomEvent<void>` |
+
+
 ## Slots
 
 | Slot       | Description              |


### PR DESCRIPTION
**Related Task:** https://inindca.atlassian.net/browse/COMUI-1254

Addition of `expanded` and `collapsed` event to `gux-dropdown-multi`

**Analysis**
There is no event  available for when a select/dropdown is closed.

**Questions**

1. What would determine the dropdown being closed. Would it be when the dropdown is in a collapsed state or when the entire component has lost focus?
2. Should this also be implemented into `gux-dropdown`