### PR TITLE
ci(github-actions): add an action to randomly assign reviewers

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,0 +1,8 @@
+groups:
+  - name: core-ui
+    reviewers: 2
+    usernames:
+      - daragh-king-genesys
+      - gavin-everett-genesys
+      - katie-bobbe-genesys
+      - MattCheely

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -1,0 +1,17 @@
+name: Reviewer Lottery
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+    branches:
+      - main
+      - maintenance/**
+
+jobs:
+  addReviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: uesteibar/reviewer-lottery@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,10 @@ on:
   push:
     branches:
       - main
-      - master
       - maintenance/**
   pull_request:
     branches:
       - main
-      - master
       - maintenance/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -50,13 +48,13 @@ jobs:
       # Build
       - name: Build
         run: npm run build
-  
+
   prComment:
     if: startsWith(github.head_ref, 'feature/')
     runs-on: ubuntu-latest
     steps:
       - uses: mshick/add-pr-comment@v1
-        with: 
-          message: "Demo will be published at https://apps.inindca.com/common-ui-docs/genesys-webcomponents/${{ github.head_ref}}"
+        with:
+          message: 'Demo will be published at https://apps.inindca.com/common-ui-docs/genesys-webcomponents/${{ github.head_ref}}'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'


### PR DESCRIPTION
As the number of folks working in the project and reviewing PRs grows, it gets more awkward to have everyone on every PR. This adds a github action to randomly assign reviewers, so that we can divide and conquer a bit more.

That said, any reviewer on a PR should fell free to add other members of the team for a particularly important or complex review, or even just when you see something that you don't fully understand. Your job as an assigned reviewer is to make sure the PR is properly reviewed, not necessarily to do all the review work yourself.
