### PR TITLE
refactor(components): switch to logWarn on a11y errors

### DIFF
--- a/src/components/legacy/gux-form-field-legacy/gux-form-field.tsx
+++ b/src/components/legacy/gux-form-field-legacy/gux-form-field.tsx
@@ -2,7 +2,7 @@ import { Component, Element, h, JSX, Prop, State } from '@stencil/core';
 
 import { OnMutation } from '../../../utils/decorator/on-mutation';
 import { randomHTMLId } from '../../../utils/dom/random-html-id';
-import { logError } from '../../../utils/error/log-error';
+import { logWarn } from '../../../utils/error/log-error';
 import { onRequiredChange } from '../../../utils/dom/on-attribute-change';
 import { preventBrowserValidationStyling } from '../../../utils/dom/prevent-browser-validation-styling';
 import { trackComponent } from '../../../usage-tracking';
@@ -347,7 +347,7 @@ export class GuxFormFieldLegacy {
       const inputHasId = !!this.input.hasAttribute('id');
       const labelHasFor = !!this.label.hasAttribute('for');
       if (!inputHasId && labelHasFor) {
-        logError(
+        logWarn(
           'gux-form-field',
           'A "for" attribute has been provided on the label but there is no corresponding id on the input. Either provide an id on the input or omit the "for" attribute from the label. If there is no input id and no "for" attribute provided, the component will automatically generate an id and link it to the "for" attribute.'
         );
@@ -362,13 +362,13 @@ export class GuxFormFieldLegacy {
         labelHasFor &&
         this.input.getAttribute('id') !== this.label.getAttribute('for')
       ) {
-        logError(
+        logWarn(
           'gux-form-field',
           'The input id and label for attribute should match.'
         );
       }
     } else {
-      logError(
+      logWarn(
         'gux-form-field',
         'A label is required for this component. If a visual label is not needed for this use case, please add localized text for a screenreader and set the label-position attribute to "screenreader" to visually hide the label.'
       );

--- a/src/components/stable/gux-radial-progress/gux-radial-progress.tsx
+++ b/src/components/stable/gux-radial-progress/gux-radial-progress.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, JSX, Prop } from '@stencil/core';
 
 import { trackComponent } from '../../../usage-tracking';
-import { logError } from '../../../utils/error/log-error';
+import { logWarn } from '../../../utils/error/log-error';
 import { randomHTMLId } from '../../../utils/dom/random-html-id';
 
 import {
@@ -55,7 +55,7 @@ export class GuxRadialProgress {
       !this.screenreaderText &&
       canShowPercentageState(this.value, this.max)
     ) {
-      logError(
+      logWarn(
         'gux-radial-progress',
         'No screenreader-text provided. Provide a localized screenreader-text property for the component.'
       );

--- a/src/components/stable/gux-radial-progress/tests/gux-radial-progress.spec.ts
+++ b/src/components/stable/gux-radial-progress/tests/gux-radial-progress.spec.ts
@@ -1,12 +1,12 @@
 jest.mock('../../../../utils/error/log-error', () => ({
   __esModule: true,
-  logError: jest.fn()
+  logWarn: jest.fn()
 }));
 
 import { newSpecPage } from '@stencil/core/testing';
 import { GuxRadialProgress } from '../gux-radial-progress';
 
-import { logError } from '../../../../utils/error/log-error';
+import { logWarn } from '../../../../utils/error/log-error';
 
 const components = [GuxRadialProgress];
 const language = 'en';
@@ -50,24 +50,24 @@ describe('gux-radial-progress', () => {
   });
 
   describe('Screenreader text requirements', () => {
-    it('should log an error if displaying progress and no screenreader text is passed in', async () => {
+    it('should log a warning message if displaying progress and no screenreader text is passed in', async () => {
       await newSpecPage({
         components,
         html: '<gux-radial-progress value="10" max="10"></gux-radial-progress>',
         language
       });
 
-      expect(logError).toHaveBeenCalled();
+      expect(logWarn).toHaveBeenCalled();
     });
 
-    it('should not log an error if displaying progress and screenreader text is passed in', async () => {
+    it('should not log a warning message if displaying progress and screenreader text is passed in', async () => {
       await newSpecPage({
         components,
         html: '<gux-radial-progress value="10" max="10" screenreader-text="Uploading file"></gux-radial-progress>',
         language
       });
 
-      expect(logError).not.toHaveBeenCalled();
+      expect(logWarn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/stable/gux-rating/gux-rating.tsx
+++ b/src/components/stable/gux-rating/gux-rating.tsx
@@ -3,7 +3,7 @@ import { Component, Element, h, Host, Listen, JSX, Prop } from '@stencil/core';
 import simulateNativeEvent from '../../../utils/dom/simulate-native-event';
 import clamp from '../../../utils/number/clamp';
 import { trackComponent } from '../../../usage-tracking';
-import { logError } from '../../../utils/error/log-error';
+import { logWarn } from '../../../utils/error/log-error';
 
 @Component({
   styleUrl: 'gux-rating.less',
@@ -129,7 +129,7 @@ export class GuxRating {
         this.root.getAttribute('aria-labelledby')
       )
     ) {
-      logError(
+      logWarn(
         'gux-rating',
         '`gux-rating` requires a label. Either provide a label and associate it with the gux-rating element using `aria-labelledby` or add an `aria-label` attribute to the gux-rating element.'
       );

--- a/src/components/stable/gux-tooltip-title/gux-tooltip-title.tsx
+++ b/src/components/stable/gux-tooltip-title/gux-tooltip-title.tsx
@@ -7,7 +7,7 @@ import {
   Method,
   State
 } from '@stencil/core';
-import { logError } from '../../../utils/error/log-error';
+import { logWarn } from '../../../utils/error/log-error';
 import { OnMutation } from '../../../utils/decorator/on-mutation';
 
 @Component({
@@ -79,12 +79,12 @@ export class GuxTooltipTitle {
   }
 
   componentDidLoad() {
-    this.logErrorNoIconSrText();
+    this.logWarnNoIconSrText();
   }
 
-  private logErrorNoIconSrText(): void {
+  private logWarnNoIconSrText(): void {
     if (this.iconOnly && !this.titleName) {
-      logError(
+      logWarn(
         'gux-tooltip-title',
         'No screenreader-text provided. Provide a localized screenreader-text property for the gux-icon. The screenreader-text property is used for the icon screenreader text and the tooltip.'
       );


### PR DESCRIPTION
Related : https://inindca.atlassian.net/browse/COMUI-1283

Switch to logWarn on a11y errors.

COMUI-1283