### PR TITLE
style(gux-tooltip-title): size icon explicitly instead of assuming 1rem

### DIFF
--- a/src/components/stable/gux-tooltip-title/gux-tooltip-title.less
+++ b/src/components/stable/gux-tooltip-title/gux-tooltip-title.less
@@ -1,4 +1,5 @@
 @import (reference) '../../../style/spacing.less';
+@import (reference) '../../../style/variables.less';
 
 gux-tooltip-title {
   overflow: hidden;
@@ -31,13 +32,14 @@ gux-tooltip {
 .gux-tooltip-icon-decorative {
   .gux-title-container {
     position: relative;
-    margin-left: calc(1rem + @spacing-2xs);
+    margin-left: calc(@gux-icon-size-default-global + @spacing-2xs);
 
     gux-icon,
     ::slotted(gux-icon) {
       position: absolute;
-      left: calc(-1rem - @spacing-2xs);
+      left: calc(-@gux-icon-size-default-global - @spacing-2xs);
       flex-shrink: 0;
+      width: @gux-icon-size-default-global;
     }
   }
 }


### PR DESCRIPTION
Changes styles in gux-tooltip-title to use `@gux-icon-size-global-default` explicitly rather than assuming the icon is 1rem.