### PR TITLE
fix(css): increase step button icon size in gux-form-field-number

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.less
@@ -12,6 +12,8 @@
 @import (reference)
   '../../functional-components/gux-form-field-help/gux-form-field-help.less';
 
+@gux-form-field-number-step-button-size: 14px;
+
 .GuxFormFieldContainerStyle();
 .GuxFormFieldErrorStyle();
 .GuxFormFieldLabelStyle();
@@ -104,16 +106,20 @@
 }
 
 .gux-step-buttons-container {
-  flex: 0 1 16px;
+  flex: 0 1 @gux-form-field-number-step-button-size;
   align-self: auto;
   order: 0;
   margin: 0 4px;
 
   .gux-step-button {
+    // Flex the <gux-icon> child to ensure it doesn't have extra descender height from being inline
+    display: flex;
     flex: 0 1 auto;
+    align-items: center;
     align-self: auto;
+    justify-content: center;
     order: 0;
-    padding: 2px;
+    padding: 0;
     color: @gux-black-90;
     background: transparent;
     border: none;
@@ -125,8 +131,9 @@
     }
 
     gux-icon {
-      width: 10px;
-      height: 10px;
+      flex: 0 0 auto;
+      width: @gux-form-field-number-step-button-size;
+      height: @gux-form-field-number-step-button-size;
     }
   }
 }


### PR DESCRIPTION
See discussion and screen captures on https://inindca.atlassian.net/browse/COMUI-1317.

This addresses feedback I got that the step buttons are too small. It trades the 2px padding on the stepper buttons for 4px more width and height of the chevron icons.

Additionally does some more specific flexbox styling to make sure the `<gux-icon>` has no extra descender height from being `inline-flex` by default. This was causing the number input to be slightly taller than other inputs in my app (I think because it was effectively `display: inline` due to the container not being `display: flex`).