### PR TITLE
feat(pagination): default number of pages to 1

### DIFF
--- a/src/components/beta/gux-pagination-beta/gux-pagination-beta.tsx
+++ b/src/components/beta/gux-pagination-beta/gux-pagination-beta.tsx
@@ -77,13 +77,8 @@ export class GuxPaginationBeta implements ComponentInterface {
   private guxpaginationchange: EventEmitter<GuxPaginationState>;
 
   private setPage(page: number): void {
-    if (page < 0) {
-      if (this.totalPages > 0) {
-        this.setPage(1);
-      } else {
-        this.setPage(0);
-      }
-
+    if (page <= 0) {
+      this.setPage(1);
       return;
     }
 
@@ -116,7 +111,7 @@ export class GuxPaginationBeta implements ComponentInterface {
     totalItems: number,
     itemsPerPage: number
   ): number {
-    return Math.ceil(totalItems / itemsPerPage);
+    return Math.max(1, Math.ceil(totalItems / itemsPerPage));
   }
 
   private calculateCurrentPage(

--- a/src/components/beta/gux-pagination-beta/tests/__snapshots__/gux-pagination-beta.spec.ts.snap
+++ b/src/components/beta/gux-pagination-beta/tests/__snapshots__/gux-pagination-beta.spec.ts.snap
@@ -881,7 +881,7 @@ exports[`gux-pagination-beta #render should render as expected (12) 1`] = `
   <mock:shadow-root>
     <div class="gux-pagination-container">
       <div class="gux-pagination-info">
-        <gux-pagination-item-counts-beta current-page="0" items-per-page="25" total-items="0">
+        <gux-pagination-item-counts-beta current-page="1" items-per-page="25" total-items="0">
           <div class="gux-pagination-item-counts-container">
             <span class="gux-pagination-item-counts-range">
               0 - 0
@@ -891,7 +891,7 @@ exports[`gux-pagination-beta #render should render as expected (12) 1`] = `
       </div>
       <div class="gux-pagination-spacer"></div>
       <div class="gux-pagination-change">
-        <gux-pagination-buttons-beta current-page="0" total-pages="0">
+        <gux-pagination-buttons-beta current-page="1" total-pages="1">
           <div class="gux-advanced gux-pagination-buttons-container">
             <div class="gux-pagination-buttons-group">
               <gux-button-slot-beta accent="secondary">
@@ -905,7 +905,65 @@ exports[`gux-pagination-beta #render should render as expected (12) 1`] = `
                 </button>
               </gux-button-slot-beta>
             </div>
-            <div class="gux-pagination-buttons-list-container"></div>
+            <div class="gux-pagination-buttons-list-container">
+              <button class="gux-pagination-buttons-list-current">
+                1
+              </button>
+            </div>
+            <div class="gux-pagination-buttons-group">
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Next">
+                  <gux-icon decorative="" icon-name="chevron-small-right"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Last">
+                  <gux-icon decorative="" icon-name="chevron-double-right"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+            </div>
+          </div>
+        </gux-pagination-buttons-beta>
+      </div>
+    </div>
+  </mock:shadow-root>
+</gux-pagination-beta>
+`;
+
+exports[`gux-pagination-beta #render should render current page as 1 when total items is 0 1`] = `
+<gux-pagination-beta current-page="1" items-per-page="25" layout="full" total-items="0">
+  <mock:shadow-root>
+    <div class="gux-pagination-container">
+      <div class="gux-pagination-info">
+        <gux-pagination-item-counts-beta current-page="1" items-per-page="25" total-items="0">
+          <div class="gux-pagination-item-counts-container">
+            <span class="gux-pagination-item-counts-range">
+              0 - 0
+            </span>
+          </div>
+        </gux-pagination-item-counts-beta>
+      </div>
+      <div class="gux-pagination-spacer"></div>
+      <div class="gux-pagination-change">
+        <gux-pagination-buttons-beta current-page="1" total-pages="1">
+          <div class="gux-advanced gux-pagination-buttons-container">
+            <div class="gux-pagination-buttons-group">
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="First">
+                  <gux-icon decorative="" icon-name="chevron-double-left"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Previous">
+                  <gux-icon decorative="" icon-name="chevron-small-left"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+            </div>
+            <div class="gux-pagination-buttons-list-container">
+              <button class="gux-pagination-buttons-list-current">
+                1
+              </button>
+            </div>
             <div class="gux-pagination-buttons-group">
               <gux-button-slot-beta accent="secondary">
                 <button disabled="" title="Next">

--- a/src/components/beta/gux-pagination-beta/tests/gux-pagination-beta.spec.ts
+++ b/src/components/beta/gux-pagination-beta/tests/gux-pagination-beta.spec.ts
@@ -105,5 +105,21 @@ describe('gux-pagination-beta', () => {
         expect(page.root).toMatchSnapshot();
       });
     });
+    it(`should render current page as 1 when total items is 0`, async () => {
+      const html = `
+      <gux-pagination-beta
+      current-page="1"
+      total-items="0"
+      items-per-page="25"
+      layout="full"
+    ></gux-pagination-beta>
+      `;
+
+      const page = await newSpecPage({ components, html, language });
+
+      expect(page.rootInstance).toBeInstanceOf(GuxPaginationBeta);
+
+      expect(page.root).toMatchSnapshot();
+    });
   });
 });

--- a/src/components/stable/gux-pagination/gux-pagination.tsx
+++ b/src/components/stable/gux-pagination/gux-pagination.tsx
@@ -61,17 +61,12 @@ export class GuxPagination implements ComponentInterface {
   private guxpaginationchange: EventEmitter<GuxPaginationState>;
 
   private setPage(page: number): void {
-    if (page < 0) {
-      if (this.totalPages > 0) {
-        this.setPage(1);
-      } else {
-        this.setPage(0);
-      }
-
+    if (page <= 0) {
+      this.setPage(1);
       return;
     }
 
-    const totalPages = this.calculatTotalPages();
+    const totalPages = this.calculateTotalPages();
     if (page > totalPages) {
       this.setPage(totalPages);
       return;
@@ -84,8 +79,8 @@ export class GuxPagination implements ComponentInterface {
     });
   }
 
-  private calculatTotalPages(): number {
-    return Math.ceil(this.totalItems / this.itemsPerPage);
+  private calculateTotalPages(): number {
+    return Math.max(1, Math.ceil(this.totalItems / this.itemsPerPage));
   }
 
   private calculateCurrentPage(): number {
@@ -138,7 +133,7 @@ export class GuxPagination implements ComponentInterface {
   }
 
   componentWillRender(): void {
-    this.totalPages = this.calculatTotalPages();
+    this.totalPages = this.calculateTotalPages();
     this.currentPage = this.calculateCurrentPage();
   }
 

--- a/src/components/stable/gux-pagination/tests/__snapshots__/gux-pagination.spec.ts.snap
+++ b/src/components/stable/gux-pagination/tests/__snapshots__/gux-pagination.spec.ts.snap
@@ -1213,11 +1213,127 @@ exports[`gux-pagination #render should render as expected (11) 1`] = `
 `;
 
 exports[`gux-pagination #render should render as expected (12) 1`] = `
-<gux-pagination current-page="-3" items-per-page="25" layout="full" total-items="0">
+<gux-pagination current-page="-3" items-per-page="25" layout="full" total-items="1">
   <mock:shadow-root>
     <div class="gux-pagination-container">
       <div class="gux-pagination-info">
-        <gux-pagination-item-counts current-page="0" items-per-page="25" total-items="0">
+        <gux-pagination-item-counts current-page="1" items-per-page="25" total-items="1">
+          <div class="gux-pagination-item-counts-container">
+            <span class="gux-pagination-item-counts-range">
+              1 - 1
+            </span>
+            <span>
+              of 1
+            </span>
+          </div>
+        </gux-pagination-item-counts>
+        <gux-pagination-items-per-page items-per-page="25">
+          <div class="gux-pagination-items-per-page-container">
+            <div class="gux-pagination-items-per-page-picker">
+              <gux-dropdown>
+                <mock:shadow-root>
+                  <gux-popup>
+                    <div class="gux-target-container-collapsed" slot="target">
+                      <button aria-expanded="false" aria-haspopup="listbox" class="gux-field gux-field-button" type="button">
+                        <div class="gux-field-content">
+                          <div class="gux-selected-option">
+                            25
+                          </div>
+                        </div>
+                        <gux-icon class="gux-expand-icon" iconname="chevron-small-down" screenreader-text="Dropdown"></gux-icon>
+                      </button>
+                    </div>
+                    <div class="gux-listbox-container" slot="popup">
+                      <slot></slot>
+                    </div>
+                  </gux-popup>
+                </mock:shadow-root>
+                <gux-listbox aria-label="Items per page" role="listbox" tabindex="0">
+                  <mock:shadow-root>
+                    <slot></slot>
+                  </mock:shadow-root>
+                  <gux-option aria-disabled="false" aria-selected="true" class="gux-selected" id="gux-option-i" role="option">
+                    <!---->
+                    25
+                  </gux-option>
+                  <gux-option aria-disabled="false" aria-selected="false" id="gux-option-i" role="option">
+                    <!---->
+                    50
+                  </gux-option>
+                  <gux-option aria-disabled="false" aria-selected="false" id="gux-option-i" role="option">
+                    <!---->
+                    75
+                  </gux-option>
+                  <gux-option aria-disabled="false" aria-selected="false" id="gux-option-i" role="option">
+                    <!---->
+                    100
+                  </gux-option>
+                </gux-listbox>
+              </gux-dropdown>
+            </div>
+            <div>
+              per page
+            </div>
+          </div>
+        </gux-pagination-items-per-page>
+      </div>
+      <div class="gux-pagination-change">
+        <gux-pagination-buttons current-page="1" total-pages="1">
+          <div class="gux-full gux-pagination-buttons-container">
+            <div class="gux-pagination-buttons-group">
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="First">
+                  <gux-icon decorative="" icon-name="chevron-double-left"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Previous">
+                  <gux-icon decorative="" icon-name="chevron-small-left"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+            </div>
+            <div class="gux-pagination-buttons-input-container">
+              <div>
+                Page
+              </div>
+              <div class="gux-pagination-buttons-input">
+                <gux-form-field-text-like label-position="screenreader">
+                  <label slot="label">
+                    Page 1 of 1
+                  </label>
+                  <input slot="input" type="text" value="1">
+                </gux-form-field-text-like>
+              </div>
+              <div>
+                of 1
+              </div>
+            </div>
+            <div class="gux-pagination-buttons-group">
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Next">
+                  <gux-icon decorative="" icon-name="chevron-small-right"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+              <gux-button-slot-beta accent="secondary">
+                <button disabled="" title="Last">
+                  <gux-icon decorative="" icon-name="chevron-double-right"></gux-icon>
+                </button>
+              </gux-button-slot-beta>
+            </div>
+          </div>
+        </gux-pagination-buttons>
+      </div>
+    </div>
+  </mock:shadow-root>
+</gux-pagination>
+`;
+
+exports[`gux-pagination #render should render current page as 1 when total items is 0 1`] = `
+<gux-pagination current-page="1" items-per-page="25" layout="full" total-items="0">
+  <mock:shadow-root>
+    <div class="gux-pagination-container">
+      <div class="gux-pagination-info">
+        <gux-pagination-item-counts current-page="1" items-per-page="25" total-items="0">
           <div class="gux-pagination-item-counts-container">
             <span class="gux-pagination-item-counts-range">
               0 - 0
@@ -1278,7 +1394,7 @@ exports[`gux-pagination #render should render as expected (12) 1`] = `
         </gux-pagination-items-per-page>
       </div>
       <div class="gux-pagination-change">
-        <gux-pagination-buttons current-page="0" total-pages="0">
+        <gux-pagination-buttons current-page="1" total-pages="1">
           <div class="gux-full gux-pagination-buttons-container">
             <div class="gux-pagination-buttons-group">
               <gux-button-slot-beta accent="secondary">
@@ -1299,13 +1415,13 @@ exports[`gux-pagination #render should render as expected (12) 1`] = `
               <div class="gux-pagination-buttons-input">
                 <gux-form-field-text-like label-position="screenreader">
                   <label slot="label">
-                    Page 0 of 0
+                    Page 1 of 1
                   </label>
-                  <input slot="input" type="text" value="0">
+                  <input slot="input" type="text" value="1">
                 </gux-form-field-text-like>
               </div>
               <div>
-                of 0
+                of 1
               </div>
             </div>
             <div class="gux-pagination-buttons-group">

--- a/src/components/stable/gux-pagination/tests/gux-pagination.spec.ts
+++ b/src/components/stable/gux-pagination/tests/gux-pagination.spec.ts
@@ -44,7 +44,7 @@ describe('gux-pagination', () => {
       { currentPage: 10, totalItems: 1000, itemsPerPage: 100, layout: 'full' },
       { currentPage: 1, totalItems: 1000, itemsPerPage: 25, layout: 'small' },
       { currentPage: -3, totalItems: 1000, itemsPerPage: 25, layout: 'full' },
-      { currentPage: -3, totalItems: 0, itemsPerPage: 25, layout: 'full' }
+      { currentPage: -3, totalItems: 1, itemsPerPage: 25, layout: 'full' }
     ].forEach(({ currentPage, totalItems, itemsPerPage, layout }, index) => {
       it(`should render as expected (${index + 1})`, async () => {
         const html = `
@@ -61,6 +61,22 @@ describe('gux-pagination', () => {
 
         expect(page.root).toMatchSnapshot();
       });
+    });
+    it(`should render current page as 1 when total items is 0`, async () => {
+      const html = `
+      <gux-pagination
+      current-page="1"
+      total-items="0"
+      items-per-page="25"
+      layout="full"
+    ></gux-pagination>
+      `;
+
+      const page = await newSpecPage({ components, html, language });
+
+      expect(page.rootInstance).toBeInstanceOf(GuxPagination);
+
+      expect(page.root).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
**Related Task :** https://inindca.atlassian.net/browse/COMUI-1313

Verified this update with UX. I think the easiest way to do this is just to set `totalItems` to 1. But the downside is that it would represent that there is 1 item in the table even though there is no data in the table. I am not sure if this is a big deal. I think that `totalItems` is only used to calculate the total page count so it should be fine.