### PR TITLE
fix(version): bump version to fix Jenkins build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-spark-components",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genesys-spark-components",
-  "version": "3.37.0",
+  "version": "3.38.0",
   "description": "Common webcomponents",
   "license": "MIT",
   "main": "dist/stencil-wrapper.js",


### PR DESCRIPTION
The failing Jenkins build gives us this error: `fatal: tag 'v3.38.0' already exists`. In this PR, I bumped the version to `3.38.0` to fix the failing build.

I also created [COMUI-1327](https://inindca.atlassian.net/browse/COMUI-1327) to fix the Jenkins issue