### PR TITLE
feat(popover) - updates to design

### DIFF
--- a/src/components/stable/gux-popover/example.html
+++ b/src/components/stable/gux-popover/example.html
@@ -3,6 +3,7 @@
   <div class="scroll-interior">
     <div id="popover-target">Example Element</div>
     <gux-popover id="popover-example" position="top" for="popover-target">
+      <span slot="title">Title</span>
       <div style="width: 200px">
         <div>popover content</div>
         <gux-dropdown filterable placeholder="Select a country">
@@ -27,7 +28,7 @@
 })()"
 >
   .scroll-container {
-    width: 300px;
+    width: 900px;
     height: 300px;
     margin: auto;
     overflow: scroll;

--- a/src/components/stable/gux-popover/gux-popover.less
+++ b/src/components/stable/gux-popover/gux-popover.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../style/shadows.less';
 @import (reference) '../../../style/spacing.less';
 @import (reference) '../../../style/zindex.less';
+@import (reference) '../../../style/typography.less';
 
 @gux-arrow-height: 5px;
 
@@ -14,9 +15,8 @@
   display: inline-block;
   padding: @gux-spacing-medium;
   background-color: @gux-grey-100;
-  border: 1px solid @gux-grey-30;
-  border-radius: @gux-spacing-2xs;
-  .gux-shadow-20();
+  border-radius: @spacing-2xs;
+  .gux-shadow-40();
 
   .gux-arrow,
   .gux-arrow::before {
@@ -42,11 +42,6 @@
     .gux-arrow {
       top: -1 * (@gux-arrow-height);
     }
-
-    .gux-arrow::before {
-      border-top: 1px solid @gux-grey-30;
-      border-left: 1px solid @gux-grey-30;
-    }
   }
 
   &[data-popper-placement='top'],
@@ -54,11 +49,6 @@
   &[data-popper-placement='top-end'] {
     .gux-arrow {
       bottom: -1 * (@gux-arrow-height);
-    }
-
-    .gux-arrow::before {
-      border-right: 1px solid @gux-grey-30;
-      border-bottom: 1px solid @gux-grey-30;
     }
   }
 
@@ -68,11 +58,6 @@
     .gux-arrow {
       right: -1 * (@gux-arrow-height);
     }
-
-    .gux-arrow::before {
-      border-top: 1px solid @gux-grey-30;
-      border-right: 1px solid @gux-grey-30;
-    }
   }
 
   &[data-popper-placement='right'],
@@ -81,10 +66,30 @@
     .gux-arrow {
       left: -1 * (@gux-arrow-height);
     }
+  }
 
-    .gux-arrow::before {
-      border-bottom: 1px solid @gux-grey-30;
-      border-left: 1px solid @gux-grey-30;
+  .gux-popover-header {
+    .body-font-bold();
+
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: @gux-spacing-medium;
+  }
+
+  gux-dismiss-button {
+    float: right;
+  }
+
+  .gux-popover-content {
+    ::slotted(*) {
+      display: flex;
+      flex-direction: column;
+      gap: @gux-spacing-medium;
+      justify-content: flex-start;
+      .body-font();
     }
   }
 }

--- a/src/components/stable/gux-popover/gux-popover.tsx
+++ b/src/components/stable/gux-popover/gux-popover.tsx
@@ -16,9 +16,11 @@ import { onHiddenChange } from '../../../utils/dom/on-attribute-change';
 import { trackComponent } from '@utils/tracking/usage';
 
 import { PopperPosition } from './gux-popover.types';
+import { getSlot } from '@utils/dom/get-slot';
 
 /**
  * @slot - popover content
+ * @slot title - Slot for popover title
  */
 
 @Component({
@@ -91,6 +93,10 @@ export class GuxPopover {
     }
   }
 
+  get titleSlot(): HTMLSlotElement | null {
+    return getSlot(this.root, 'title');
+  }
+
   private runPopper(): void {
     const forElement = document.getElementById(this.for);
 
@@ -160,6 +166,17 @@ export class GuxPopover {
     }
   }
 
+  private renderDismissButton(): JSX.Element {
+    if (this.displayDismissButton) {
+      return (
+        <gux-dismiss-button
+          onClick={this.dismiss.bind(this)}
+          position="inherit"
+        ></gux-dismiss-button>
+      ) as JSX.Element;
+    }
+  }
+
   render(): JSX.Element {
     return (
       <div
@@ -167,11 +184,10 @@ export class GuxPopover {
         class="gux-popover-wrapper"
       >
         <div class="gux-arrow" data-popper-arrow />
-        {this.displayDismissButton && (
-          <gux-dismiss-button
-            onClick={this.dismiss.bind(this)}
-          ></gux-dismiss-button>
-        )}
+        <div class={{ 'gux-popover-header': Boolean(this.titleSlot) }}>
+          <slot name="title"></slot>
+          {this.renderDismissButton()}
+        </div>
         <div class="gux-popover-content">
           <slot />
         </div>

--- a/src/components/stable/gux-popover/readme.md
+++ b/src/components/stable/gux-popover/readme.md
@@ -29,9 +29,10 @@
 
 ## Slots
 
-| Slot | Description     |
-| ---- | --------------- |
-|      | popover content |
+| Slot      | Description            |
+| --------- | ---------------------- |
+|           | popover content        |
+| `"title"` | Slot for popover title |
 
 
 ## Dependencies

--- a/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
+++ b/src/components/stable/gux-popover/tests/__snapshots__/gux-popover.spec.ts.snap
@@ -1,17 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gux-popover #render should render popover 1`] = `
-<gux-popover for="popover-target" id="popover-example" position="top">
+<gux-popover display-dismiss-button="" for="popover-target" id="popover-example" position="top">
   <mock:shadow-root>
     <div class="gux-popover-wrapper">
       <div class="gux-arrow" data-popper-arrow></div>
+      <div class="gux-popover-header">
+        <slot name="title"></slot>
+        <gux-dismiss-button position="inherit"></gux-dismiss-button>
+      </div>
       <div class="gux-popover-content">
         <slot></slot>
       </div>
     </div>
   </mock:shadow-root>
-  <div>
-    popover content
+  <span slot="title">
+    Title of popover
+  </span>
+  <div slot="content">
+    <div>
+      popover content
+    </div>
   </div>
+  <gux-button accent="ghost" slot="action-button">
+    Button 1
+  </gux-button>
+  <gux-button accent="primary" slot="action-button">
+    Button 2
+  </gux-button>
 </gux-popover>
 `;

--- a/src/components/stable/gux-popover/tests/gux-popover.e2e.ts
+++ b/src/components/stable/gux-popover/tests/gux-popover.e2e.ts
@@ -8,9 +8,19 @@ describe('gux-popover', () => {
         <div id="popover-target">
           Example Element
         </div>
-        <gux-popover position="top" for="popover-target">
+        <gux-popover
+        id="popover-example"
+        position="top"
+        for="popover-target"
+        display-dismiss-button
+      >
+        <span slot="title">Title of popover</span>
+        <div slot="content">
           <div>popover content</div>
-        </gux-popover>
+        </div>
+        <gux-button slot="action-button" accent="ghost">Button 1</gux-button>
+        <gux-button slot="action-button" accent="primary">Button 2</gux-button>
+      </gux-popover>
       </div>
       `
     });
@@ -24,13 +34,13 @@ describe('gux-popover', () => {
     const page = await newSparkE2EPage({
       html: `
       <div lang="en">
-        <div id="popover-target">
-          Example Element
-        </div>
-        <gux-popover position="top" for="popover-target" display-dismiss-button>
-          <div>popover content</div>
-        </gux-popover>
+      <div id="popover-target">
+        Example Element
       </div>
+      <gux-popover position="top" for="popover-target" display-dismiss-button>
+        <div slot ="title">popover content</div>
+      </gux-popover>
+    </div>
       `
     });
 
@@ -48,17 +58,28 @@ describe('gux-popover', () => {
         <div id="popover-target">
           Example Element
         </div>
-        <gux-popover position="top" for="popover-target">
+        <gux-popover
+        id="popover-example"
+        position="top"
+        for="popover-target"
+      >
+        <span slot="title">Title of popover</span>
+        <div slot="content">
           <div>popover content</div>
-        </gux-popover>
+        </div>
+        <gux-button slot="action-button" accent="ghost">Button 1</gux-button>
+        <gux-button slot="action-button" accent="primary">Button 2</gux-button>
+      </gux-popover>
       </div>
       `
     });
 
     const component = await page.find('gux-popover');
-    component.setProperty('displayDismissDutton', false);
+    component.setProperty('displayDismissButton', false);
     await page.waitForChanges();
-    const button = await page.find('pierce/gux-dismiss-button');
+    const button = await page.find(
+      'pierce/.gux-popover-header .gux-popover-header gux-dismiss-button'
+    );
     await a11yCheck(page);
     expect(button).toBeNull();
   });

--- a/src/components/stable/gux-popover/tests/gux-popover.spec.ts
+++ b/src/components/stable/gux-popover/tests/gux-popover.spec.ts
@@ -28,9 +28,19 @@ describe('gux-popover', () => {
             <div id="popover-target">
               Example Element
             </div>
-            <gux-popover id="popover-example" position="top" for="popover-target">
+            <gux-popover
+            id="popover-example"
+            position="top"
+            for="popover-target"
+            display-dismiss-button
+          >
+            <span slot="title">Title of popover</span>
+            <div slot="content">
               <div>popover content</div>
-            </gux-popover>
+            </div>
+            <gux-button slot="action-button" accent="ghost">Button 1</gux-button>
+            <gux-button slot="action-button" accent="primary">Button 2</gux-button>
+          </gux-popover>
           </div>
         `
       }

--- a/src/style/shadows.less
+++ b/src/style/shadows.less
@@ -11,3 +11,7 @@
 .gux-shadow-30 {
   box-shadow: 0 8px 24px fade(@gux-black-30, 40%);
 }
+
+.gux-shadow-40 {
+  box-shadow: 0 3px 14px fade(@gux-black-50, 22%);
+}


### PR DESCRIPTION
Updates to the popover design include the following : 

- Increased the padding of the wrapper to 20px. Currently there is no token available for 20px so it was requested to do @ spacing-medium  * 1.25.
- New Shadow 40 added to the shadows file and also added to the popover design ( I wasn't sure if a separate PR was needed for this type of change )
-  An optional button slot has also been added where you can have two buttons the spacing between them is 8px and they are right aligned.
- Updated the fonts for the title and content to correct fonts.
- Padding between the sections is 16px from title to content and 20px from content to footer.
- Removal of border on the component itself.
- Update to arrow design on popover. ( UX input needed )

- Dismiss button is now aligned with the popover title.

Design : https://www.figma.com/file/gVF1uEon5OI8BVCIy7kGY8/Pop-Overs?node-id=6%3A1939
