### PR TITLE
fix(table): add px unit to columns when scaling

### DIFF
--- a/src/components/beta/gux-table/gux-table.tsx
+++ b/src/components/beta/gux-table/gux-table.tsx
@@ -50,7 +50,6 @@ export class GuxTable {
   private tableId: string = randomHTMLId('gux-table');
   private columnsWidths: object = {};
   private tableWidth: number = this.getElementComputedWidth(this.slottedTable);
-
   /**
    * Indicates that vertical scroll is presented for table
    */
@@ -557,8 +556,8 @@ export class GuxTable {
       columnsStyles += `[gs-table-id=${
         this.tableId
       }] th[data-column-name="${column}"]{
-        width:${String(this.columnsWidths[column])};
-        min-width:${String(this.columnsWidths[column])};
+        width:${String(this.columnsWidths[column])}px;
+        min-width:${String(this.columnsWidths[column])}px;
       }`;
     });
 


### PR DESCRIPTION
**Related ticket :** https://inindca.atlassian.net/browse/COMUI-1339

Currently with the resizing of columns in **gux-table**  there is not a unit supplied when resizing so it returns "Invalid property value" in some other repos. By adding `px` this should hopefully resolve those issues.

Example of wem-webcomponents repository,
<img width="479" alt="Screenshot 2022-11-10 at 17 00 28" src="https://user-images.githubusercontent.com/101644078/201308137-50c50e79-d540-4cd0-a132-b404f03f59f5.png">
