### PR TITLE
feat(css): allow margin overrides on .gux-form-field-fieldset-container

### DIFF
--- a/src/components/stable/gux-form-field/functional-components/gux-form-field-fieldset-container/gux-form-field-fieldset-container.less
+++ b/src/components/stable/gux-form-field/functional-components/gux-form-field-fieldset-container/gux-form-field-fieldset-container.less
@@ -5,7 +5,12 @@
   .gux-form-field-fieldset-container {
     min-width: 0;
     padding: 0;
-    margin: @spacing-medium 0;
+    // Use CSS variable with fallback to allow apps to override these margins by setting the variable
+    // value as desired within their own selector scope. Apps should only override in order to provide
+    // design-spec spacing via some other means, such as `gap` in a CSS grid or Flexbox layout.
+    margin: var(--gux-form-field-fieldset-container-margin-top, @spacing-medium)
+      0 var(--gux-form-field-fieldset-container-margin-bottom, @spacing-medium)
+      0;
     border: none;
   }
 }


### PR DESCRIPTION
Same idea as #903 but for .gux-form-field-fieldset-container. Make the baked-in margins overridable via CSS variables. See [COMUI-1362](https://inindca.atlassian.net/browse/COMUI-1362) for more info.