### PR TITLE
feat(table-toolbar) - updates to design / bug fixes

### DIFF
--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.less
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.less
@@ -2,6 +2,7 @@
 @import (reference) '../../../../style/spacing.less';
 
 .gux-sr-only {
+  display: flex;
   .gux-sr-only-clip();
 }
 

--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.less
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.less
@@ -4,11 +4,14 @@
 @import (reference) '../../../../style/spacing.less';
 
 :host {
-  display: block;
-  margin: 0 @gux-spacing-2xs 0 @gux-spacing-2xs;
+  display: none;
   -webkit-user-select: none;
   user-select: none;
   .body-font();
+}
+
+:host(.gux-show-menu) {
+  display: block;
 }
 
 & > * {

--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.tsx
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.tsx
@@ -1,4 +1,13 @@
-import { Component, Element, h, JSX, Listen, State } from '@stencil/core';
+import {
+  Component,
+  Element,
+  h,
+  JSX,
+  Listen,
+  Prop,
+  State,
+  Host
+} from '@stencil/core';
 
 import { trackComponent } from '@utils/tracking/usage';
 import { OnClickOutside } from '../../../../utils/decorator/on-click-outside';
@@ -19,6 +28,9 @@ export class GuxTableToolbarMenuButton {
 
   @Element()
   private root: HTMLElement;
+
+  @Prop()
+  showMenu: boolean;
 
   @State()
   expanded: boolean = false;
@@ -98,29 +110,31 @@ export class GuxTableToolbarMenuButton {
 
   render(): JSX.Element {
     return (
-      <gux-popup expanded={this.expanded}>
-        <div slot="target" class="gux-toolbar-menu-container">
-          <gux-button-slot-beta class="gux-menu-button">
-            <button
-              type="button"
-              ref={el => (this.dropdownButton = el)}
-              onMouseUp={() => this.toggle()}
-              aria-haspopup="true"
-              aria-expanded={this.expanded.toString()}
-            >
-              <gux-icon
-                screenreader-text={this.i18n('additionalActions')}
-                icon-name="menu-kebab-horizontal"
-              ></gux-icon>
-            </button>
-          </gux-button-slot-beta>
-        </div>
-        <div class="gux-list-container" slot="popup">
-          <gux-list ref={el => (this.listElement = el)}>
-            <slot />
-          </gux-list>
-        </div>
-      </gux-popup>
+      <Host class={{ 'gux-show-menu': this.showMenu }}>
+        <gux-popup expanded={this.expanded}>
+          <div slot="target" class="gux-toolbar-menu-container">
+            <gux-button-slot-beta class="gux-menu-button">
+              <button
+                type="button"
+                ref={el => (this.dropdownButton = el)}
+                onMouseUp={() => this.toggle()}
+                aria-haspopup="true"
+                aria-expanded={this.expanded.toString()}
+              >
+                <gux-icon
+                  screenreader-text={this.i18n('additionalActions')}
+                  icon-name="menu-kebab-horizontal"
+                ></gux-icon>
+              </button>
+            </gux-button-slot-beta>
+          </div>
+          <div class="gux-list-container" slot="popup">
+            <gux-list ref={el => (this.listElement = el)}>
+              <slot />
+            </gux-list>
+          </div>
+        </gux-popup>
+      </Host>
     ) as JSX.Element;
   }
 }

--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/readme.md
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property   | Attribute   | Description | Type      | Default     |
+| ---------- | ----------- | ----------- | --------- | ----------- |
+| `showMenu` | `show-menu` |             | `boolean` | `undefined` |
+
+
 ## Dependencies
 
 ### Used by

--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar.less
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar.less
@@ -46,11 +46,17 @@
       align-items: center;
     }
 
-    .separator {
-      width: 1px;
-      margin-right: @gux-spacing-medium;
-      margin-left: @gux-spacing-medium;
-      background: @gux-grey-50;
+    .gux-contextual-wrapper {
+      padding-right: @spacing-xs;
+      border-right: 1px solid @gux-grey-50;
+    }
+
+    .gux-permanent-menu-primary-wrapper {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: nowrap;
+      gap: @spacing-2xs;
+      margin-left: @spacing-xs;
     }
   }
 }

--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar.service.tsx
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar.service.tsx
@@ -8,7 +8,9 @@ export function setAccent(
 ): void {
   ([].concat(actions) as HTMLGuxTableToolbarCustomActionElement[]).forEach(
     action => {
-      action.accent = accent;
+      if (action != null) {
+        action.accent = accent;
+      }
     }
   );
 }
@@ -20,7 +22,9 @@ export function expandActions(
 ): void {
   ([].concat(actions) as HTMLGuxTableToolbarCustomActionElement[]).forEach(
     action => {
-      action.iconOnly = false;
+      if (action != null) {
+        action.iconOnly = false;
+      }
     }
   );
 }
@@ -32,7 +36,9 @@ export function collapseActions(
 ): void {
   ([].concat(actions) as HTMLGuxTableToolbarCustomActionElement[]).forEach(
     action => {
-      action.iconOnly = true;
+      if (action != null) {
+        action.iconOnly = true;
+      }
     }
   );
 }
@@ -42,12 +48,16 @@ export function collapseActionsAll(
   actionsPerm: HTMLGuxTableToolbarCustomActionElement[],
   actionPrimary: HTMLGuxTableToolbarCustomActionElement
 ): void {
-  const arrayActions = actionsPerm.concat(
-    actionsFilterContextual,
-    actionPrimary
-  );
-  arrayActions.forEach(action => {
-    action.iconOnly = true;
+  (
+    [].concat(
+      actionsFilterContextual,
+      actionsPerm,
+      actionPrimary
+    ) as HTMLGuxTableToolbarCustomActionElement[]
+  ).forEach(action => {
+    if (action != null) {
+      action.iconOnly = true;
+    }
   });
 }
 
@@ -56,11 +66,15 @@ export function expandActionsAll(
   actionsPerm: HTMLGuxTableToolbarCustomActionElement[],
   actionPrimary: HTMLGuxTableToolbarCustomActionElement
 ): void {
-  const arrayActions = actionsFilterContextual.concat(
-    actionsPerm,
-    actionPrimary
-  );
-  arrayActions.forEach(action => {
-    action.iconOnly = false;
+  (
+    [].concat(
+      actionsPerm,
+      actionPrimary,
+      actionsFilterContextual
+    ) as HTMLGuxTableToolbarCustomActionElement[]
+  ).forEach(action => {
+    if (action != null) {
+      action.iconOnly = false;
+    }
   });
 }

--- a/src/components/beta/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
+++ b/src/components/beta/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
@@ -8,29 +8,32 @@ exports[`gux-table-toolbar-beta #render should render table toolbar as expected 
     </div>
     <div class="section-spacing"></div>
     <div class="gux-contextual-permanent-primary">
-      <slot name="contextual-actions"></slot>
-      <div class="separator"></div>
-      <slot name="permanent-actions"></slot>
-      <gux-table-toolbar-menu-button>
-        <mock:shadow-root>
-          <gux-popup>
-            <div class="gux-toolbar-menu-container" slot="target">
-              <gux-button-slot-beta class="gux-menu-button">
-                <button aria-expanded="false" aria-haspopup="true" type="button">
-                  <gux-icon icon-name="menu-kebab-horizontal" screenreader-text="Additional Actions"></gux-icon>
-                </button>
-              </gux-button-slot-beta>
-            </div>
-            <div class="gux-list-container" slot="popup">
-              <gux-list>
-                <slot></slot>
-              </gux-list>
-            </div>
-          </gux-popup>
-        </mock:shadow-root>
-        <slot name="menu-actions"></slot>
-      </gux-table-toolbar-menu-button>
-      <slot name="primary-action"></slot>
+      <div class="gux-contextual-wrapper">
+        <slot name="contextual-actions"></slot>
+      </div>
+      <div class="gux-permanent-menu-primary-wrapper">
+        <slot name="permanent-actions"></slot>
+        <gux-table-toolbar-menu-button class="gux-show-menu" show-menu="">
+          <mock:shadow-root>
+            <gux-popup>
+              <div class="gux-toolbar-menu-container" slot="target">
+                <gux-button-slot-beta class="gux-menu-button">
+                  <button aria-expanded="false" aria-haspopup="true" type="button">
+                    <gux-icon icon-name="menu-kebab-horizontal" screenreader-text="Additional Actions"></gux-icon>
+                  </button>
+                </gux-button-slot-beta>
+              </div>
+              <div class="gux-list-container" slot="popup">
+                <gux-list>
+                  <slot></slot>
+                </gux-list>
+              </div>
+            </gux-popup>
+          </mock:shadow-root>
+          <slot name="menu-actions"></slot>
+        </gux-table-toolbar-menu-button>
+        <slot name="primary-action"></slot>
+      </div>
     </div>
   </mock:shadow-root>
   <div slot="search-and-filter">

--- a/src/utils/dom/get-slot.ts
+++ b/src/utils/dom/get-slot.ts
@@ -2,5 +2,5 @@ export function getSlot(
   element: HTMLElement,
   slotName: string
 ): HTMLSlotElement {
-  return element.querySelector(`[slot=${slotName}]`);
+  return element?.querySelector(`[slot=${slotName}]`);
 }


### PR DESCRIPTION
**Related Ticket** : https://inindca.atlassian.net/browse/COMUI-1358

Issues resolved in this PR include the following,

**Vertical bar seperator** : Updated so that the vertical bar only presents itself when there are contextual actions present. Also updated logic to include if contextual actions are the only actions present in the toolbar the vertical bar will not be displayed.

**Menu updates**

- The menu will now dynamically show. If the user doesn't supply any actions to the menu-actions slot the menu will not show until it reaches a condensed state.  
- The menu will show in all states full -> condensed and vice versa if actions have been supplied or that the menu-actions slot exists.

**Console Errors :**  

1. Fixed console errors that were being caused if you were to remove one of the named slots eg 'contextual-actions' this would cause an error. As a fix for is checking if it the slot has nodes first before doing the array conversion. There may be a better solution for this but I went with this one.
2. Fixed console error that was being caused when appending the 'permanent' 'contextual' and 'primary' slots to the menu actions slot. If one of the slots wasnt present it would produce an error. Applied a check to ensure they are present before executing the `appendChild`.

**Other Optimisations** : 

1. Optimised some of the resize functions in the services file.
2. Created a wrapper for permanent-menu-primary to accommodate for the vertical bar seperator.