### PR TITLE
feat(dismiss-button): addition of optional positioning

### DIFF
--- a/src/components/stable/gux-dismiss-button/gux-dismiss-button.less
+++ b/src/components/stable/gux-dismiss-button/gux-dismiss-button.less
@@ -12,6 +12,10 @@ button {
   border: none;
   border-radius: 4px;
 
+  &.gux-inherit {
+    position: inherit;
+  }
+
   &:not(:disabled):focus,
   &:not(:disabled):hover {
     color: @gux-black-50;

--- a/src/components/stable/gux-dismiss-button/gux-dismiss-button.tsx
+++ b/src/components/stable/gux-dismiss-button/gux-dismiss-button.tsx
@@ -1,10 +1,11 @@
-import { Component, Element, h, JSX } from '@stencil/core';
+import { Component, Element, h, JSX, Prop } from '@stencil/core';
 
 import { trackComponent } from '../../../usage-tracking';
 
 import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
 
 import translationResources from './i18n/en.json';
+import { GuxDismissButtonPosition } from './gux-dismiss-button.types';
 
 @Component({
   styleUrl: 'gux-dismiss-button.less',
@@ -17,14 +18,21 @@ export class GuxDismissButton {
   @Element()
   private root: HTMLElement;
 
+  @Prop()
+  position: GuxDismissButtonPosition = 'absolute';
+
   async componentWillLoad(): Promise<void> {
-    trackComponent(this.root);
+    trackComponent(this.root, { variant: this.position });
     this.i18n = await buildI18nForComponent(this.root, translationResources);
   }
 
   render(): JSX.Element {
     return (
-      <button type="button" title={this.i18n('dismiss')}>
+      <button
+        class={this.position == 'inherit' ? 'gux-inherit' : undefined}
+        type="button"
+        title={this.i18n('dismiss')}
+      >
         <gux-icon
           icon-name="close"
           screenreader-text={this.i18n('dismiss')}

--- a/src/components/stable/gux-dismiss-button/gux-dismiss-button.types.ts
+++ b/src/components/stable/gux-dismiss-button/gux-dismiss-button.types.ts
@@ -1,0 +1,1 @@
+export type GuxDismissButtonPosition = 'absolute' | 'inherit';

--- a/src/components/stable/gux-dismiss-button/readme.md
+++ b/src/components/stable/gux-dismiss-button/readme.md
@@ -5,6 +5,13 @@ This component is meant for use in other components as a dismiss button.
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property   | Attribute  | Description | Type                      | Default      |
+| ---------- | ---------- | ----------- | ------------------------- | ------------ |
+| `position` | `position` |             | `"absolute" \| "inherit"` | `'absolute'` |
+
+
 ## Dependencies
 
 ### Used by


### PR DESCRIPTION
**Related Ticket :**  https://inindca.atlassian.net/browse/COMUI-1373

Currently the `gux-dismiss-button` is absolutely positioned with no way to have it free flowing. Added `isInline` property to allow for this with the default positioning being to the top right of the component.