### PR TITLE
fix(table-toolbar): add delegatesFocus to custom action component

### DIFF
--- a/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
+++ b/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
@@ -10,7 +10,7 @@ import { GuxTableToolbarActionAccent } from '../gux-table-toolbar-action-accents
 @Component({
   styleUrl: 'gux-table-toolbar-custom-action.less',
   tag: 'gux-table-toolbar-custom-action',
-  shadow: true
+  shadow: { delegatesFocus: true }
 })
 export class GuxTableToolbarCustomAction {
   @Element()


### PR DESCRIPTION
Issue : Focus ring is sometimes shown & sometimes not when clicking the buttons.

Reason : `gux-toolbar-custom-action` is rendered inside of `gux-toolbar-action`.