### PR TITLE
feat(inline-alert) - text will now wrap instead of truncating

### DIFF
--- a/src/components/beta/gux-alert/example.html
+++ b/src/components/beta/gux-alert/example.html
@@ -3,7 +3,9 @@
 <h2>Inline Alert Examples</h2>
 <div class="alerts">
   <gux-inline-alert-beta accent="info"
-    ><strong>Note:</strong> This is an information alert.</gux-inline-alert-beta
+    ><strong>Note:</strong> This is an information alert. This alert will
+    demonstrate how the alert will wrap if needed in certain
+    instances.</gux-inline-alert-beta
   >
   <gux-inline-alert-beta accent="success"
     ><strong>Note:</strong> This is a success alert.</gux-inline-alert-beta
@@ -15,6 +17,16 @@
     ><strong>Note:</strong> This is a warning alert.</gux-inline-alert-beta
   >
 </div>
+
+<h2>Truncated Inline Alert Examples</h2>
+
+<h2>1 line truncated inline alert example</h2>
+<gux-inline-alert-beta accent="info"
+  ><gux-truncate-beta max-lines="1">
+    This is an information message to demonstrate that this alert will truncate
+    after 1 line. You can also alter the max lines to be 2.</gux-truncate-beta
+  ></gux-inline-alert-beta
+>
 
 <style>
   .alerts {

--- a/src/components/beta/gux-alert/gux-inline-alert.less
+++ b/src/components/beta/gux-alert/gux-inline-alert.less
@@ -16,15 +16,16 @@
   align-items: center;
   justify-content: flex-start;
   max-width: 540px;
-  height: 28px;
   padding: @gux-spacing-2xs @gux-spacing-xs;
   border-radius: @spacing-2xs;
   .body-font();
 
   gux-icon {
     flex-shrink: 0;
+    align-self: flex-start;
     width: 16px;
     height: 16px;
+    margin-top: @gux-spacing-3xs;
   }
 
   gux-tooltip-title {

--- a/src/components/beta/gux-alert/gux-inline-alert.tsx
+++ b/src/components/beta/gux-alert/gux-inline-alert.tsx
@@ -51,12 +51,10 @@ export class GuxAlert {
         }}
       >
         <gux-icon icon-name={this.getIcon(this.accent)} decorative></gux-icon>
-        <gux-tooltip-title>
-          <span>
-            <div class="gux-sr-only">{this.i18n(this.accent)}</div>
-            <slot />
-          </span>
-        </gux-tooltip-title>
+        <div class="gux-message-wrapper">
+          <div class="gux-sr-only">{this.i18n(this.accent)}</div>
+          <slot />
+        </div>
       </div>
     ) as JSX.Element;
   }

--- a/src/components/beta/gux-alert/readme.md
+++ b/src/components/beta/gux-alert/readme.md
@@ -24,14 +24,11 @@
 ### Depends on
 
 - [gux-icon](../../stable/gux-icon)
-- [gux-tooltip-title](../../stable/gux-tooltip-title)
 
 ### Graph
 ```mermaid
 graph TD;
   gux-inline-alert-beta --> gux-icon
-  gux-inline-alert-beta --> gux-tooltip-title
-  gux-tooltip-title --> gux-tooltip
   style gux-inline-alert-beta fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/stable/gux-tooltip-title/readme.md
+++ b/src/components/stable/gux-tooltip-title/readme.md
@@ -33,7 +33,6 @@ Type: `Promise<void>`
 ### Used by
 
  - [gux-badge-beta](../../beta/gux-badge)
- - [gux-inline-alert-beta](../../beta/gux-alert)
  - [gux-tab](../gux-tabs/gux-tab)
  - [gux-tab-advanced](../gux-tabs-advanced/gux-tab-advanced)
  - [gux-tag-beta](../../beta/gux-tag)
@@ -47,7 +46,6 @@ Type: `Promise<void>`
 graph TD;
   gux-tooltip-title --> gux-tooltip
   gux-badge-beta --> gux-tooltip-title
-  gux-inline-alert-beta --> gux-tooltip-title
   gux-tab --> gux-tooltip-title
   gux-tab-advanced --> gux-tooltip-title
   gux-tag-beta --> gux-tooltip-title


### PR DESCRIPTION
Confirmed these changes with UX. Related Ticket : https://inindca.atlassian.net/browse/COMUI-1395

Related Spark docs to be updated accordingly.

`gux-truncate-beta` can be used if the end consumer wishes to truncate the message.