### PR TITLE
fix(gux-time-picker): vertically center clock button

### DIFF
--- a/src/components/beta/gux-time-picker/gux-time-picker.less
+++ b/src/components/beta/gux-time-picker/gux-time-picker.less
@@ -19,6 +19,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
+    gap: @spacing-xs;
     align-content: stretch;
     align-items: center;
     justify-content: center;
@@ -65,7 +66,7 @@
     }
 
     .gux-input-time-am-pm-selector {
-      padding: 0 0 0 @spacing-xs;
+      padding: 0;
       font-size: 12px;
       font-weight: bold;
       color: @gux-black-50;
@@ -84,10 +85,14 @@
     }
 
     .gux-clock-button {
+      // Also make the button itself a flex container to ensure vertical centering.
+      display: flex;
       flex: 0 1 auto;
+      align-items: center;
       align-self: auto;
+      justify-content: center;
       order: 0;
-      padding: 0 0 0 @spacing-xs;
+      padding: 0;
       color: @gux-black-90;
       background: transparent;
       border: none;


### PR DESCRIPTION
Makes the clock button `display: flex` so that the icon within is properly centered.