### PR TITLE
fix(gux-datepicker): vertically center calendar button

### DIFF
--- a/src/components/stable/gux-datepicker/gux-datepicker.less
+++ b/src/components/stable/gux-datepicker/gux-datepicker.less
@@ -101,8 +101,12 @@
         }
 
         button {
+          // Also make the button itself a flex container to ensure vertical centering.
+          display: flex;
           flex: 0 1 auto;
+          align-items: center;
           align-self: auto;
+          justify-content: center;
           order: 0;
           padding: 2px;
           color: @gux-black-90;


### PR DESCRIPTION
Makes the calendar button display: flex so that the icon within is properly centered.

See #1052 for the same fix to gux-time-picker