### PR TITLE
fix: check MutationObservers before calling disconnect

### DIFF
--- a/src/components/beta/gux-popover-list/gux-popover-list.tsx
+++ b/src/components/beta/gux-popover-list/gux-popover-list.tsx
@@ -149,7 +149,9 @@ export class GuxPopoverList {
 
   disconnectedCallback(): void {
     this.destroyPopper();
-    this.hiddenObserver.disconnect();
+    if (this.hiddenObserver) {
+      this.hiddenObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/beta/gux-table/gux-sort-control/gux-sort-control.tsx
+++ b/src/components/beta/gux-table/gux-sort-control/gux-sort-control.tsx
@@ -79,7 +79,9 @@ export class GuxSortControl {
   }
 
   disconnectedCallback() {
-    this.thObserver.disconnect();
+    if (this.thObserver) {
+      this.thObserver.disconnect();
+    }
   }
 
   private onClick(): void {

--- a/src/components/beta/gux-table/gux-table-select-menu/gux-table-select-popover/gux-table-header-popover.tsx
+++ b/src/components/beta/gux-table/gux-table-select-menu/gux-table-select-popover/gux-table-header-popover.tsx
@@ -119,7 +119,9 @@ export class GuxTableSelectPopover {
 
   disconnectedCallback(): void {
     this.destroyPopper();
-    this.hiddenObserver.disconnect();
+    if (this.hiddenObserver) {
+      this.hiddenObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-color/gux-input-color.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-color/gux-input-color.tsx
@@ -79,7 +79,9 @@ export class GuxInputColor {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-number/gux-input-number.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-number/gux-input-number.tsx
@@ -132,7 +132,9 @@ export class GuxInputNumber {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-range/gux-input-range.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-range/gux-input-range.tsx
@@ -117,7 +117,9 @@ export class GuxInputRange {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
     clearInterval(this.valueWatcherId);
   }
 

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-search/gux-input-search.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-search/gux-input-search.tsx
@@ -87,7 +87,9 @@ export class GuxInputSearch {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-select/gux-input-select.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-select/gux-input-select.tsx
@@ -33,7 +33,9 @@ export class GuxInputSelect {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/components/gux-input-text-like/gux-input-text-like.tsx
+++ b/src/components/legacy/gux-form-field-legacy/components/gux-input-text-like/gux-input-text-like.tsx
@@ -80,7 +80,9 @@ export class GuxInputTextLike {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/legacy/gux-form-field-legacy/gux-form-field.tsx
+++ b/src/components/legacy/gux-form-field-legacy/gux-form-field.tsx
@@ -110,7 +110,9 @@ export class GuxFormFieldLegacy {
   }
 
   disconnectedCallback(): void {
-    this.requiredObserver.disconnect();
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   private renderInputCheckbox(hasError: boolean): JSX.Element {

--- a/src/components/legacy/gux-list-legacy/gux-list.tsx
+++ b/src/components/legacy/gux-list-legacy/gux-list.tsx
@@ -134,7 +134,9 @@ export class GuxListLegacy {
   }
 
   disconnectedCallback(): void {
-    this.observer.disconnect();
+    if (this.observer) {
+      this.observer.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.tsx
+++ b/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.tsx
@@ -146,7 +146,9 @@ export class GuxAdvancedDropdown {
   }
 
   disconnectedCallback() {
-    this.slotObserver.disconnect();
+    if (this.slotObserver) {
+      this.slotObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-content-search/gux-content-search.tsx
+++ b/src/components/stable/gux-content-search/gux-content-search.tsx
@@ -92,7 +92,9 @@ export class GuxContentSearch {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-checkbox/gux-form-field-checkbox.tsx
@@ -57,7 +57,9 @@ export class GuxFormFieldCheckbox {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-color/gux-form-field-color.tsx
@@ -76,8 +76,12 @@ export class GuxFormFieldColor {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-dropdown/gux-form-field-dropdown.tsx
@@ -88,8 +88,12 @@ export class GuxFormFieldDropdown {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-number/gux-form-field-number.tsx
@@ -116,8 +116,12 @@ export class GuxFormFieldNumber {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-radio/gux-form-field-radio.tsx
@@ -57,7 +57,9 @@ export class GuxFormFieldRadio {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-range/gux-form-field-range.tsx
@@ -128,8 +128,12 @@ export class GuxFormField {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
 
     clearInterval(this.valueWatcherId);
   }

--- a/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-search/gux-form-field-search.tsx
@@ -103,8 +103,12 @@ export class GuxFormFieldSearch {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-select/gux-form-field-select.tsx
@@ -76,8 +76,12 @@ export class GuxFormFieldSelect {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
@@ -122,8 +122,12 @@ export class GuxFormFieldTextLike {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.tsx
@@ -85,8 +85,12 @@ export class GuxFormFieldTextarea {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-form-field/components/gux-form-field-time-picker/gux-form-field-time-picker.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-time-picker/gux-form-field-time-picker.tsx
@@ -94,8 +94,12 @@ export class GuxFormFieldTimePicker {
   }
 
   disconnectedCallback(): void {
-    this.disabledObserver.disconnect();
-    this.requiredObserver.disconnect();
+    if (this.disabledObserver) {
+      this.disabledObserver.disconnect();
+    }
+    if (this.requiredObserver) {
+      this.requiredObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/components/stable/gux-popover/gux-popover.tsx
+++ b/src/components/stable/gux-popover/gux-popover.tsx
@@ -155,7 +155,9 @@ export class GuxPopover {
 
   disconnectedCallback(): void {
     this.destroyPopper();
-    this.hiddenObserver.disconnect();
+    if (this.hiddenObserver) {
+      this.hiddenObserver.disconnect();
+    }
   }
 
   render(): JSX.Element {

--- a/src/utils/decorator/on-mutation.ts
+++ b/src/utils/decorator/on-mutation.ts
@@ -33,7 +33,9 @@ export function OnMutation(opt: MutationObserverInit): OnMutationDecorator {
     };
 
     proto.disconnectedCallback = function () {
-      onMutationObserver.disconnect();
+      if (onMutationObserver) {
+        onMutationObserver.disconnect();
+      }
 
       return disconnectedCallback && disconnectedCallback.call(this);
     };

--- a/src/utils/decorator/on-resize.ts
+++ b/src/utils/decorator/on-resize.ts
@@ -33,7 +33,9 @@ export function OnResize(): OnResizeDecorator {
     };
 
     proto.disconnectedCallback = function () {
-      onMutationObserver.disconnect();
+      if (onMutationObserver) {
+        onMutationObserver.disconnect();
+      }
 
       return disconnectedCallback && disconnectedCallback.call(this);
     };


### PR DESCRIPTION
Add defensive checks to all invocations of MutationObserver#disconnect() within disconnectedCallback(), as there are cases where disconnectedCallback() is invoked prior to the initialization of the MutationObserver.