### PR TITLE
fix(tabs-advanced): fix issue where "enter" key does not open dropdown

### DIFF
--- a/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.tsx
+++ b/src/components/stable/gux-tabs-advanced/gux-tab-advanced/gux-tab-advanced.tsx
@@ -90,6 +90,7 @@ export class GuxTabAdvanced {
       case 'ArrowDown':
       case 'Enter':
         if (eventIsFrom('.gux-tab-options-button', event)) {
+          event.preventDefault();
           this.popoverHidden = false;
           this.focusFirstItemInPopupList();
         }


### PR DESCRIPTION
**Issue**
Enter key does not open dropdown.

**Related Ticket**
https://inindca.atlassian.net/browse/COMUI-1405

I also fixed where it was not focusing the first element when the popover opened via a click.

I think potentially the `gux-context-menu` could be used to replace the current implementation.