### PR TITLE
fix(button-multi): align button and button-multi colours for disabled state.

### DIFF
--- a/src/components/stable/gux-button-multi/gux-button-multi.tsx
+++ b/src/components/stable/gux-button-multi/gux-button-multi.tsx
@@ -164,7 +164,7 @@ export class GuxButtonMulti {
 
   render(): JSX.Element {
     return (
-      <gux-popup expanded={this.isOpen} disabled={this.disabled}>
+      <gux-popup expanded={this.isOpen}>
         <div slot="target" class="gux-button-multi-container">
           <gux-button-slot-beta
             class="gux-dropdown-button"


### PR DESCRIPTION
**Issue** 
Disabled `gux-button` and disabled `gux-multi-button` are different Colours.

**Related Ticket**
https://inindca.atlassian.net/browse/COMUI-1412

**Fix**
In `gux-button-multi` a disabled attribute was applied to both the popup and button element causing an overlap in css. Removed the disabled attribute from popup element.