### PR TITLE
fix(textarea): textarea width and height incorrect in some instances

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-textarea/gux-form-field-textarea.less
@@ -62,7 +62,7 @@
 
   .gux-input {
     position: relative;
-    display: block;
+    display: flex;
     border: 1px solid @gux-black-100;
     border-radius: 4px;
     outline: none;
@@ -132,8 +132,6 @@
 }
 
 .gux-textarea-sizing-properties() {
-  min-width: 100%;
-  max-width: 100%;
   min-height: (@body-font-line-height * 4) + 8 + 2; // 4 lines + padding + border
   padding: 4px 12px;
   margin: 0;


### PR DESCRIPTION
Slotted textarea is too wide & too short  in some instances. Reproducible on the vue-2 playground.
Width seens to be due to box-sizing cascading in or its omission somewhere, similar issue on line-height of a parent could be the height issue.

Simplest fix is to harden the sizing by letting flexbox handle it.