### PR TITLE
feat(css): add -focused and -focused-within classes for small focus ring

### DIFF
--- a/src/style/focus.less
+++ b/src/style/focus.less
@@ -10,6 +10,18 @@
   }
 }
 
+.gux-focus-ring-small-focused {
+  &:focus {
+    .gux-focus-ring-small();
+  }
+}
+
+.gux-focus-ring-small-focused-within {
+  &:focus-within {
+    .gux-focus-ring-small();
+  }
+}
+
 .gux-focus-ring {
   outline: none;
   box-shadow: 0 0 0 1px @gux-grey-100, 0 0 0 4px @gux-blue-90;


### PR DESCRIPTION
Add helper CSS classes for applying `.gux-focus-ring-small` styles to a focused or focused-within element, similar to the ones already there that apply the `.gux-focus-ring` styles.