### PR TITLE
fix(table): fix infinite scale issue

### DIFF
--- a/src/components/beta/gux-table/gux-table.tsx
+++ b/src/components/beta/gux-table/gux-table.tsx
@@ -424,7 +424,11 @@ export class GuxTable {
 
   /** Scale column pixel widths equal when a resize is observed */
   private scaleColumnWidths(): void {
-    if (!this.columnResizeState && this.resizableColumns) {
+    if (
+      !this.columnResizeState &&
+      this.resizableColumns &&
+      !this.isHorizontalScroll
+    ) {
       const oldColumnWidths = this.calculateColumnWidths(this.tableColumns);
       const oldTableWidth = this.tableWidth;
       const newTableWidth = this.getElementComputedWidth(this.slottedTable);


### PR DESCRIPTION
I had to make this new PR as I accidentally removed the example file from the table and it sort of messed up when I rebased. @thomas-c-dillon  solution fixes the issue and makes logical sense to me that when the horizontal scroll bars appear that the scaleColumnWidths should not execute.

Closed PR : https://github.com/MyPureCloud/genesys-webcomponents/pull/1005


COMUI-1352