### PR TITLE
feat(time-picker) - bug fixes and improvements

### DIFF
--- a/src/components/beta/gux-time-picker/gux-time-picker.service.tsx
+++ b/src/components/beta/gux-time-picker/gux-time-picker.service.tsx
@@ -108,7 +108,6 @@ export function getHourDisplayValue(
   clockType: GuxClockType
 ): string {
   const [hour] = getDisplayValue(value, clockType).split(':');
-
   return hour;
 }
 
@@ -120,7 +119,6 @@ export function getMinuteDisplayValue(value: GuxISOHourMinute): string {
 
 export function isAm(value: GuxISOHourMinute): boolean {
   const [hour] = value.split(':');
-
   return parseInt(hour, 10) < 12;
 }
 
@@ -140,18 +138,26 @@ export function getValidValueHourChange(
   value: GuxISOHourMinute,
   clockType: GuxClockType,
   change: string,
-  selectionStart: number
+  selectionStart: number,
+  hourInputLength: number
 ): GuxISOHourMinute {
   const [displayValue, minute] = getDisplayValue(value, clockType).split(':');
 
   let wantedDisplayValue = displayValue;
 
   if (change === 'Backspace') {
-    wantedDisplayValue = wantedDisplayValue
-      .split('')
-      .filter((_, i) => i !== selectionStart - 1)
-      .join('')
-      .padStart(2, '0');
+    if (clockType == '12h' && hourInputLength == 1) {
+      wantedDisplayValue = wantedDisplayValue
+        .split('')
+        .filter((_, i) => i == selectionStart - 1)
+        .join('');
+    } else {
+      wantedDisplayValue = wantedDisplayValue
+        .split('')
+        .filter((_, i) => i !== selectionStart - 1)
+        .join('')
+        .padStart(2, '0');
+    }
   } else {
     wantedDisplayValue = parseInt(
       wantedDisplayValue.slice(0, selectionStart) +
@@ -171,7 +177,6 @@ export function getValidValueHourChange(
       wantedDisplayValue = change.padStart(2, '0');
     }
   }
-
   return getValue(`${wantedDisplayValue}:${minute}`, clockType, isAm(value));
 }
 

--- a/src/components/beta/gux-time-picker/gux-time-picker.tsx
+++ b/src/components/beta/gux-time-picker/gux-time-picker.tsx
@@ -173,18 +173,21 @@ export class GuxTimePickerBeta {
       case '6':
       case '7':
       case '8':
-      case '9': {
-        event.preventDefault();
-        this.updateValue(
-          getValidValueHourChange(
-            this.value,
-            this.clockType,
-            event.key,
-            this.hourInputElement.selectionStart
-          )
-        );
+      case '9':
+        {
+          event.preventDefault();
+          this.hourInputElement.setSelectionRange(2, 2);
+          this.updateValue(
+            getValidValueHourChange(
+              this.value,
+              this.clockType,
+              event.key,
+              this.hourInputElement.selectionStart,
+              this.hourInputElement.value.length
+            )
+          );
+        }
         break;
-      }
       default:
         event.preventDefault();
     }
@@ -218,6 +221,7 @@ export class GuxTimePickerBeta {
       case '8':
       case '9': {
         event.preventDefault();
+        this.minuteInputElement.setSelectionRange(2, 2);
         this.updateValue(
           getValidValueMinuteChange(
             this.value,

--- a/src/components/beta/gux-time-picker/tests/gux-time-picker.service.spec.ts
+++ b/src/components/beta/gux-time-picker/tests/gux-time-picker.service.spec.ts
@@ -615,248 +615,126 @@ describe('gux-time-picker.service', () => {
   });
 
   describe('#getValidValueHourChange', () => {
+    const element = document.createElement('input');
+    element.type = 'text';
+    element.selectionStart = 2;
     [
       {
         input: '00:00',
         clockType: '24h',
         change: 'Backspace',
-        selectionStart: 2,
-        expectedOutput: '00:00'
-      },
-      {
-        input: '00:00',
-        clockType: '24h',
-        change: 'Backspace',
-        selectionStart: 1,
+        hourInputTime: '00',
         expectedOutput: '00:00'
       },
       {
         input: '00:00',
         clockType: '24h',
         change: '5',
-        selectionStart: 2,
+        hourInputTime: '00',
         expectedOutput: '05:00'
       },
       {
         input: '00:00',
         clockType: '24h',
         change: '9',
-        selectionStart: 2,
+        hourInputTime: '00',
         expectedOutput: '09:00'
       },
       {
         input: '00:00',
         clockType: '24h',
         change: '0',
-        selectionStart: 2,
+        hourInputTime: '00',
         expectedOutput: '00:00'
       },
       {
         input: '10:00',
         clockType: '24h',
         change: '5',
-        selectionStart: 2,
+        hourInputTime: '10',
         expectedOutput: '05:00'
       },
       {
         input: '11:00',
         clockType: '24h',
         change: '9',
-        selectionStart: 2,
+        hourInputTime: '11',
         expectedOutput: '19:00'
       },
       {
         input: '12:00',
         clockType: '24h',
         change: '0',
-        selectionStart: 2,
+        hourInputTime: '12',
         expectedOutput: '20:00'
       },
       {
         input: '15:00',
         clockType: '24h',
         change: '3',
-        selectionStart: 2,
+        hourInputTime: '15',
         expectedOutput: '03:00'
       },
       {
         input: '18:00',
         clockType: '24h',
         change: '9',
-        selectionStart: 2,
+        hourInputTime: '18',
         expectedOutput: '09:00'
       },
       {
         input: '21:00',
         clockType: '24h',
         change: '3',
-        selectionStart: 2,
+        hourInputTime: '21',
         expectedOutput: '13:00'
       },
-      {
-        input: '00:00',
-        clockType: '24h',
-        change: '0',
-        selectionStart: 1,
-        expectedOutput: '00:00'
-      },
-      {
-        input: '15:00',
-        clockType: '24h',
-        change: '3',
-        selectionStart: 1,
-        expectedOutput: '13:00'
-      },
-      {
-        input: '18:00',
-        clockType: '24h',
-        change: '9',
-        selectionStart: 1,
-        expectedOutput: '19:00'
-      },
-      {
-        input: '21:00',
-        clockType: '24h',
-        change: '3',
-        selectionStart: 1,
-        expectedOutput: '23:00'
-      },
-      {
-        input: '21:00',
-        clockType: '24h',
-        change: '9',
-        selectionStart: 1,
-        expectedOutput: '09:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: 'Backspace',
-        selectionStart: 2,
-        expectedOutput: '01:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: 'Backspace',
-        selectionStart: 1,
-        expectedOutput: '02:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: '5',
-        selectionStart: 2,
-        expectedOutput: '05:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: '9',
-        selectionStart: 2,
-        expectedOutput: '09:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: '0',
-        selectionStart: 2,
-        expectedOutput: '00:00'
-      },
+
       {
         input: '10:00',
         clockType: '12h',
         change: '5',
-        selectionStart: 2,
+        hourInputTime: '10',
         expectedOutput: '05:00'
       },
       {
         input: '11:00',
         clockType: '12h',
         change: '9',
-        selectionStart: 2,
+        hourInputTime: '11',
         expectedOutput: '09:00'
       },
       {
         input: '12:00',
         clockType: '12h',
         change: '0',
-        selectionStart: 2,
+        hourInputTime: '12',
         expectedOutput: '12:00'
-      },
-      {
-        input: '15:00',
-        clockType: '12h',
-        change: '3',
-        selectionStart: 2,
-        expectedOutput: '15:00'
-      },
-      {
-        input: '18:00',
-        clockType: '12h',
-        change: '9',
-        selectionStart: 2,
-        expectedOutput: '21:00'
-      },
-      {
-        input: '21:00',
-        clockType: '12h',
-        change: '3',
-        selectionStart: 2,
-        expectedOutput: '15:00'
-      },
-      {
-        input: '00:00',
-        clockType: '12h',
-        change: '0',
-        selectionStart: 1,
-        expectedOutput: '10:00'
-      },
-      {
-        input: '15:00',
-        clockType: '12h',
-        change: '3',
-        selectionStart: 1,
-        expectedOutput: '15:00'
-      },
-      {
-        input: '18:00',
-        clockType: '12h',
-        change: '9',
-        selectionStart: 1,
-        expectedOutput: '21:00'
-      },
-      {
-        input: '21:00',
-        clockType: '12h',
-        change: '3',
-        selectionStart: 1,
-        expectedOutput: '15:00'
-      },
-      {
-        input: '21:00',
-        clockType: '12h',
-        change: '9',
-        selectionStart: 1,
-        expectedOutput: '21:00'
       }
     ].forEach(
       ({
         input,
         clockType,
         change,
-        selectionStart,
+        hourInputTime,
         expectedOutput
       }: {
         input: GuxISOHourMinute;
         clockType: GuxClockType;
         change: string;
-        selectionStart: number;
+        hourInputTime: string;
         expectedOutput: GuxISOHourMinute;
       }) => {
-        it(`should work as expected for "${input}", change "${change}" and selectionStart "${selectionStart}"`, async () => {
+        it(`should work as expected for "${input}", change "${change}"`, async () => {
+          element.setAttribute('value', hourInputTime);
           expect(
-            getValidValueHourChange(input, clockType, change, selectionStart)
+            getValidValueHourChange(
+              input,
+              clockType,
+              change,
+              element.selectionStart,
+              element.value.length
+            )
           ).toBe(expectedOutput);
         });
       }
@@ -941,6 +819,67 @@ describe('gux-time-picker.service', () => {
           expect(getValidValueMinuteChange(input, change, selectionStart)).toBe(
             expectedOutput
           );
+        });
+      }
+    );
+  });
+  describe('#getValidHourChange, prevent backspace if there is a leading zero in 12hour clock', () => {
+    const element = document.createElement('input');
+    element.type = 'text';
+    [
+      {
+        input: '09:00',
+        change: 'Backspace',
+        clockType: '12h',
+        hourInputTime: '09',
+        expectedOutput: '09:00'
+      },
+      {
+        input: '02:00',
+        change: 'Backspace',
+        clockType: '12h',
+        hourInputTime: '02',
+        expectedOutput: '02:00'
+      },
+      {
+        input: '03:00',
+        change: 'Backspace',
+        clockType: '12h',
+        hourInputTime: '03',
+        expectedOutput: '03:00'
+      },
+      {
+        input: '04:00',
+        change: 'Backspace',
+        clockType: '12h',
+        hourInputTime: '04',
+        expectedOutput: '04:00'
+      }
+    ].forEach(
+      ({
+        input,
+        change,
+        clockType,
+        hourInputTime,
+        expectedOutput
+      }: {
+        input: GuxISOHourMinute;
+        change: string;
+        clockType: GuxClockType;
+        hourInputTime: string;
+        expectedOutput: GuxISOHourMinute;
+      }) => {
+        it(`should prevent a ${change} when there is a leading zero on a 12 hour input`, async () => {
+          element.setAttribute('value', hourInputTime);
+          expect(
+            getValidValueHourChange(
+              input,
+              clockType,
+              change,
+              element.selectionStart,
+              element.value.length
+            )
+          ).toBe(expectedOutput);
         });
       }
     );


### PR DESCRIPTION
**Related Ticket:** https://inindca.atlassian.net/browse/COMUI-1437

Open to suggestions on how to further improve the time-picker input keyboard interactions.

A few things which have changed:

I tried to make it more functional like the native time input  although there is slight differences https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time
- I have added a leading `0` to the `12` hour time input before it just displayed the time as eg `9:00` instead of `09:00`. I am not sure was there a reason behind this to begin with ? (Could this be seen as a breaking change)
- Bug **(COMUI-1432)** should be resolved with this change so when typing in a digit the cursor will always start at the end of the input and not the current position of the cursor.
- Bug **(COMUI-1430)** should be resolved which is that in the 12hr hour input you cannot backspace if there is a leading 0 as this would be an invalid hour.
