### PR TITLE
feat(popover-beta): update to "for" attribute to search shadowRoot

### DIFF
--- a/src/components/beta/gux-popover-beta/gux-popover-beta.tsx
+++ b/src/components/beta/gux-popover-beta/gux-popover-beta.tsx
@@ -20,6 +20,7 @@ import {
 import { OnClickOutside } from '../../../utils/decorator/on-click-outside';
 import { trackComponent } from '@utils/tracking/usage';
 import { getSlot } from '@utils/dom/get-slot';
+import { findElementById } from '@utils/dom/find-element-by-id';
 
 /**
  * @slot - popover content
@@ -75,7 +76,7 @@ export class GuxPopoverBeta {
   @OnClickOutside({ triggerEvents: 'mousedown' })
   checkForClickOutside(event: MouseEvent) {
     const clickPath = event.composedPath();
-    const forElement = document.getElementById(this.for);
+    const forElement = findElementById(this.root, this.for);
     const clickedForElement = clickPath.includes(forElement);
 
     if (
@@ -93,7 +94,7 @@ export class GuxPopoverBeta {
 
   private runUpdatePosition(): void {
     this.cleanupUpdatePosition = autoUpdate(
-      document.getElementById(this.for),
+      findElementById(this.root, this.for),
       this.popupElement,
       () => this.updatePosition(),
       {
@@ -106,7 +107,7 @@ export class GuxPopoverBeta {
   }
 
   private updatePosition(): void {
-    const forElement = document.getElementById(this.for);
+    const forElement = findElementById(this.root, this.for);
     // This is 13 because this makes the arrow look aligned
     const arrowLen = 13;
 

--- a/src/utils/dom/find-element-by-id.ts
+++ b/src/utils/dom/find-element-by-id.ts
@@ -1,0 +1,13 @@
+export function findElementById(
+  root: HTMLElement,
+  forElementId: string
+): HTMLElement {
+  let rootNode = root.getRootNode();
+  let forElement: HTMLElement;
+
+  while (rootNode && !forElement) {
+    forElement = (rootNode as Document)?.getElementById(forElementId);
+    rootNode = rootNode.getRootNode();
+  }
+  return forElement;
+}


### PR DESCRIPTION
This update to the `for` attribute logic will unblock me in the current `pagination-beta` updates where I am using the `gux-popover-beta` within the shadowDOM of another component. I have tested this locally and it resolves the issue.

If you were wondering how I am using the `popover` this is still WIP but just for clarity : https://github.com/MyPureCloud/genesys-webcomponents/blob/feature/COMUI-1225/src/components/beta/gux-pagination-beta/gux-pagination-buttons-beta/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx

 @MattCheely Edit: getRootNode() works well!

I can implement this into stable popover also once approved.