### PR TITLE
test(axe): adding 2 axe test to increase coverage

### DIFF
--- a/src/components/beta/gux-announce/tests/__snapshots__/gux-announce.e2e.ts.snap
+++ b/src/components/beta/gux-announce/tests/__snapshots__/gux-announce.e2e.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-announce-beta #render should render component as expected (1) 1`] = `"<gux-announce-beta aria-live=\\"polite\\" hydrated=\\"\\"> This is some text to read </gux-announce-beta>"`;
+
+exports[`gux-announce-beta #render should render component as expected (2) 1`] = `"<gux-announce-beta politeness=\\"assertive\\" aria-live=\\"assertive\\" hydrated=\\"\\"> This is some text to read </gux-announce-beta>"`;
+
+exports[`gux-announce-beta #render should render component as expected (3) 1`] = `"<gux-announce-beta politeness=\\"off\\" aria-live=\\"off\\" hydrated=\\"\\"> This is some text to read </gux-announce-beta>"`;
+
+exports[`gux-announce-beta #render should render component as expected (4) 1`] = `"<gux-announce-beta politeness=\\"polite\\" aria-live=\\"polite\\" hydrated=\\"\\"> This is some text to read </gux-announce-beta>"`;

--- a/src/components/beta/gux-announce/tests/__snapshots__/gux-announce.spec.ts.snap
+++ b/src/components/beta/gux-announce/tests/__snapshots__/gux-announce.spec.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gux-announce-beta #render should render component as expected (1) 1`] = `
+<gux-announce-beta aria-live="polite">
+  <mock:shadow-root>
+    <slot></slot>
+    <div></div>
+  </mock:shadow-root>
+  This is some text to read
+</gux-announce-beta>
+`;
+
+exports[`gux-announce-beta #render should render component as expected (2) 1`] = `
+<gux-announce-beta aria-live="assertive" politeness="assertive">
+  <mock:shadow-root>
+    <slot></slot>
+    <div></div>
+  </mock:shadow-root>
+  This is some text to read
+</gux-announce-beta>
+`;
+
+exports[`gux-announce-beta #render should render component as expected (3) 1`] = `
+<gux-announce-beta aria-live="off" politeness="off">
+  <mock:shadow-root>
+    <slot></slot>
+    <div></div>
+  </mock:shadow-root>
+  This is some text to read
+</gux-announce-beta>
+`;
+
+exports[`gux-announce-beta #render should render component as expected (4) 1`] = `
+<gux-announce-beta aria-live="polite" politeness="polite">
+  <mock:shadow-root>
+    <slot></slot>
+    <div></div>
+  </mock:shadow-root>
+  This is some text to read
+</gux-announce-beta>
+`;

--- a/src/components/beta/gux-announce/tests/gux-announce.e2e.ts
+++ b/src/components/beta/gux-announce/tests/gux-announce.e2e.ts
@@ -1,0 +1,21 @@
+import { newSparkE2EPage, a11yCheck } from '../../../../test/e2eTestUtils';
+
+describe('gux-announce-beta', () => {
+  describe('#render', () => {
+    [
+      '<gux-announce-beta> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="assertive"> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="off"> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="polite"> This is some text to read </gux-announce-beta>'
+    ].forEach((html, index) => {
+      it(`should render component as expected (${index + 1})`, async () => {
+        const page = await newSparkE2EPage({ html });
+        const element = await page.find('gux-announce-beta');
+
+        await a11yCheck(page);
+
+        expect(element.outerHTML).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/components/beta/gux-announce/tests/gux-announce.spec.ts
+++ b/src/components/beta/gux-announce/tests/gux-announce.spec.ts
@@ -1,0 +1,22 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GuxAnnounce } from '../gux-announce';
+
+const components = [GuxAnnounce];
+const language = 'en';
+
+describe('gux-announce-beta', () => {
+  describe('#render', () => {
+    [
+      '<gux-announce-beta> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="assertive"> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="off"> This is some text to read </gux-announce-beta>',
+      '<gux-announce-beta politeness="polite"> This is some text to read </gux-announce-beta>'
+    ].forEach((html, index) => {
+      it(`should render component as expected (${index + 1})`, async () => {
+        const page = await newSpecPage({ components, html, language });
+
+        expect(page.root).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/components/beta/gux-loading-message/tests/gux-loading-message.e2e.ts
+++ b/src/components/beta/gux-loading-message/tests/gux-loading-message.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newSparkE2EPage, a11yCheck } from '../../../../test/e2eTestUtils';
 
 describe('gux-loading-message-beta', () => {
   it('renders', async () => {
@@ -7,8 +7,10 @@ describe('gux-loading-message-beta', () => {
         <span slot="additional-guidance">Thank you for waiting.</span>
         <gux-radial-progress slot="progress" />
         </gux-loading-message-beta>`;
-    const page = await newE2EPage({ html });
+    const page = await newSparkE2EPage({ html });
     const element = await page.find('gux-loading-message-beta');
+
+    await a11yCheck(page);
 
     expect(element.innerHTML).toMatchSnapshot();
   });


### PR DESCRIPTION
There were a few questions around accessibility recently & we reported that we were covered by automated Axe tests.
This PR is to bring us in line with the report by adding the a11yCheck to gux-loading-message & gux-announce.

Also added some snapshots to gux-announce while I was there.