### PR TITLE
feat(tooltip): addition of findElementByID util to tooltip

### DIFF
--- a/src/components/stable/gux-tooltip/gux-tooltip.tsx
+++ b/src/components/stable/gux-tooltip/gux-tooltip.tsx
@@ -14,6 +14,7 @@ import {
 import { randomHTMLId } from '../../../utils/dom/random-html-id';
 import { trackComponent } from '@utils/tracking/usage';
 import { GuxTooltipPlacements } from './gux-tooltip.types';
+import { findElementById } from '@utils/dom/find-element-by-id';
 
 /**
  * @slot - Content of the tooltip
@@ -89,7 +90,7 @@ export class GuxTooltip {
 
   private getForElement(): void {
     if (this.for) {
-      this.forElement = document.getElementById(this.for);
+      this.forElement = findElementById(this.root, this.for);
     } else {
       this.forElement = this.root.parentElement;
     }


### PR DESCRIPTION
Related Ticket : https://inindca.atlassian.net/browse/COMUI-1544

This should be the final blocker for me on the `pagination-beta` updates. I am using the `tooltip` in the same context as the `popover-beta` where it cannot find the `for` attribute.

WIP branch for clarity : 
https://github.com/MyPureCloud/genesys-webcomponents/blob/9a24ccd14e428b8abca3288ebbab6ae78792a437/src/components/beta/gux-pagination-beta/gux-pagination-buttons-beta/gux-pagination-ellipsis-button/gux-pagination-ellipsis-button.tsx
