### PR TITLE
feat(form-field-text-like): allow slotted number input

### DIFF
--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.light.less
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.light.less
@@ -1,0 +1,13 @@
+gux-form-field-text-like {
+  // Suppress browser native numeric stepper arrow buttons for <input type="number">.
+  // Implementers who want stepper buttons should be using gux-form-field-number component.
+  input[type='number'] {
+    -moz-appearance: textfield;
+
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      margin: 0;
+      -webkit-appearance: none;
+    }
+  }
+}

--- a/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
+++ b/src/components/stable/gux-form-field/components/gux-form-field-text-like/gux-form-field-text-like.tsx
@@ -187,7 +187,7 @@ export class GuxFormFieldTextLike {
 
   private setInput(): void {
     this.input = this.root.querySelector(
-      'input[type="email"][slot="input"], input[type="password"][slot="input"], input[type="text"][slot="input"]'
+      'input[type="email"][slot="input"], input[type="number"][slot="input"], input[type="password"][slot="input"], input[type="text"][slot="input"]'
     );
 
     this.hasContent = hasContent(this.input);

--- a/src/components/stable/gux-form-field/gux-form-field.light.less
+++ b/src/components/stable/gux-form-field/gux-form-field.light.less
@@ -3,3 +3,4 @@
 @import './components/gux-form-field-radio/gux-form-field-radio.light.less';
 @import './components/gux-form-field-range/gux-form-field-range.light.less';
 @import './components/gux-form-field-search/gux-form-field-search.light.less';
+@import './components/gux-form-field-text-like/gux-form-field-text-like.light.less';


### PR DESCRIPTION
My use case is a number input that uses the "suffix" feature of form-field-text-like