### PR TITLE
feat(badge): allow custom colors

### DIFF
--- a/src/components/beta/gux-badge/example.html
+++ b/src/components/beta/gux-badge/example.html
@@ -31,19 +31,17 @@
 
 <h2>Custom colors</h2>
 <div class="badges">
-  <gux-badge-beta color="custom" class="custom">Custom</gux-badge-beta>
-  <gux-badge-beta color="custom" class="custom">
+  <style>
+    .custom {
+      color: white;
+      background-color: rebeccapurple;
+    }
+  </style>
+  <gux-badge-beta color="inherit" class="custom">Custom</gux-badge-beta>
+  <gux-badge-beta color="inherit" class="custom">
     <gux-icon icon-name="subtract" decorative></gux-icon>No Impact
   </gux-badge-beta>
 </div>
-<p>
-  Define the following custom properties in your CSS to apply custom colors to
-  the text & background.
-</p>
-<ul>
-  <li>--gux-badge-text-color</li>
-  <li>-gux-badge-background-color</li>
-</ul>
 <gux-inline-alert-beta accent="error" class="custom-color-warning">
   <strong>Important:</strong>
   Color contrast must be at least 4.5:1 to pass WCAG AA guidelines.
@@ -63,11 +61,6 @@
   gux-badge-beta {
     max-width: 100px;
     margin: 4px;
-  }
-
-  .custom {
-    --gux-badge-background-color: rebeccapurple;
-    --gux-badge-text-color: white;
   }
 
   .custom-color-warning {

--- a/src/components/beta/gux-badge/example.html
+++ b/src/components/beta/gux-badge/example.html
@@ -29,6 +29,29 @@
   </gux-badge-beta>
 </div>
 
+<h2>Custom colors</h2>
+<div class="badges">
+  <gux-badge-beta color="custom" class="custom">Custom</gux-badge-beta>
+  <gux-badge-beta color="custom" class="custom">
+    <gux-icon icon-name="subtract" decorative></gux-icon>No Impact
+  </gux-badge-beta>
+</div>
+<p>
+  Define the following custom properties in your CSS to apply custom colors to
+  the text & background.
+</p>
+<ul>
+  <li>--gux-badge-text-color</li>
+  <li>-gux-badge-background-color</li>
+</ul>
+<gux-inline-alert-beta accent="error" class="custom-color-warning">
+  <strong>Important:</strong>
+  Color contrast must be at least 4.5:1 to pass WCAG AA guidelines.
+  <a href="https://webaim.org/resources/contrastchecker/" target="_blank">
+    Check contrast
+  </a>
+</gux-inline-alert-beta>
+
 <style>
   .badges {
     display: flex;
@@ -40,5 +63,14 @@
   gux-badge-beta {
     max-width: 100px;
     margin: 4px;
+  }
+
+  .custom {
+    --gux-badge-background-color: rebeccapurple;
+    --gux-badge-text-color: white;
+  }
+
+  .custom-color-warning {
+    margin-top: 16px;
   }
 </style>

--- a/src/components/beta/gux-badge/example.html
+++ b/src/components/beta/gux-badge/example.html
@@ -30,7 +30,7 @@
 </div>
 
 <h2>Custom colors</h2>
-<div class="badges">
+<div class="badges custom-badges">
   <style>
     .custom {
       color: white;
@@ -41,14 +41,14 @@
   <gux-badge-beta color="inherit" class="custom">
     <gux-icon icon-name="subtract" decorative></gux-icon>No Impact
   </gux-badge-beta>
+  <gux-inline-alert-beta accent="error" class="custom-color-warning">
+    <strong>Important:</strong>
+    Color contrast must be at least 4.5:1 to pass WCAG AA guidelines.
+    <a href="https://webaim.org/resources/contrastchecker/" target="_blank">
+      Check contrast
+    </a>
+  </gux-inline-alert-beta>
 </div>
-<gux-inline-alert-beta accent="error" class="custom-color-warning">
-  <strong>Important:</strong>
-  Color contrast must be at least 4.5:1 to pass WCAG AA guidelines.
-  <a href="https://webaim.org/resources/contrastchecker/" target="_blank">
-    Check contrast
-  </a>
-</gux-inline-alert-beta>
 
 <style>
   .badges {
@@ -61,9 +61,14 @@
   gux-badge-beta {
     max-width: 100px;
     margin: 4px;
+    background-color: black;
+  }
+
+  .custom-badges {
+    display: block;
   }
 
   .custom-color-warning {
-    margin-top: 16px;
+    margin-top: 8px;
   }
 </style>

--- a/src/components/beta/gux-badge/gux-badge.less
+++ b/src/components/beta/gux-badge/gux-badge.less
@@ -6,7 +6,8 @@
 // Style
 :host {
   display: inline-block;
-  border-radius: @gux-spacing-2xs;
+  height: fit-content;
+  border-radius: 100%;
 }
 
 .gux-badge {

--- a/src/components/beta/gux-badge/gux-badge.less
+++ b/src/components/beta/gux-badge/gux-badge.less
@@ -74,4 +74,9 @@
       background-color: @gux-alert-green-60;
     }
   }
+
+  &.gux-custom {
+    color: var(--gux-badge-text-color, @gux-black-50);
+    background-color: var(--gux-badge-background-color, @gux-grey-60);
+  }
 }

--- a/src/components/beta/gux-badge/gux-badge.less
+++ b/src/components/beta/gux-badge/gux-badge.less
@@ -6,6 +6,7 @@
 // Style
 :host {
   display: inline-block;
+  border-radius: @gux-spacing-2xs;
 }
 
 .gux-badge {
@@ -75,8 +76,8 @@
     }
   }
 
-  &.gux-custom {
-    color: var(--gux-badge-text-color, @gux-black-50);
-    background-color: var(--gux-badge-background-color, @gux-grey-60);
+  &.gux-inherit {
+    color: inherit;
+    background-color: inherit;
   }
 }

--- a/src/components/beta/gux-badge/gux-badge.types.ts
+++ b/src/components/beta/gux-badge/gux-badge.types.ts
@@ -1,1 +1,1 @@
-export type GuxBadgeColor = 'neutral' | 'green' | 'yellow' | 'red';
+export type GuxBadgeColor = 'neutral' | 'green' | 'yellow' | 'red' | 'custom';

--- a/src/components/beta/gux-badge/gux-badge.types.ts
+++ b/src/components/beta/gux-badge/gux-badge.types.ts
@@ -1,1 +1,1 @@
-export type GuxBadgeColor = 'neutral' | 'green' | 'yellow' | 'red' | 'custom';
+export type GuxBadgeColor = 'neutral' | 'green' | 'yellow' | 'red' | 'inherit';

--- a/src/components/beta/gux-badge/i18n/en.json
+++ b/src/components/beta/gux-badge/i18n/en.json
@@ -7,5 +7,5 @@
   "yellow-bold": "badge with label: {label}, color: yellow bold",
   "red": "badge with label: {label}, color: red",
   "red-bold": "badge with label: {label}, color: red bold",
-  "custom": "badge with label: {label}, color: custom"
+  "inherit": "badge with label: {label}, color: inherited"
 }

--- a/src/components/beta/gux-badge/i18n/en.json
+++ b/src/components/beta/gux-badge/i18n/en.json
@@ -6,5 +6,6 @@
   "yellow": "badge with label: {label}, color: yellow",
   "yellow-bold": "badge with label: {label}, color: yellow bold",
   "red": "badge with label: {label}, color: red",
-  "red-bold": "badge with label: {label}, color: red bold"
+  "red-bold": "badge with label: {label}, color: red bold",
+  "custom": "badge with label: {label}, color: custom"
 }

--- a/src/components/beta/gux-badge/i18n/en.json
+++ b/src/components/beta/gux-badge/i18n/en.json
@@ -7,5 +7,5 @@
   "yellow-bold": "badge with label: {label}, color: yellow bold",
   "red": "badge with label: {label}, color: red",
   "red-bold": "badge with label: {label}, color: red bold",
-  "inherit": "badge with label: {label}, color: inherited"
+  "inherit": "badge with label: {label}"
 }

--- a/src/components/beta/gux-badge/readme.md
+++ b/src/components/beta/gux-badge/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property | Attribute | Description             | Type                                        | Default     |
-| -------- | --------- | ----------------------- | ------------------------------------------- | ----------- |
-| `bold`   | `bold`    | Bold badge.             | `boolean`                                   | `false`     |
-| `color`  | `color`   | Badge background color. | `"green" \| "neutral" \| "red" \| "yellow"` | `'neutral'` |
+| Property | Attribute | Description             | Type                                                    | Default     |
+| -------- | --------- | ----------------------- | ------------------------------------------------------- | ----------- |
+| `bold`   | `bold`    | Bold badge.             | `boolean`                                               | `false`     |
+| `color`  | `color`   | Badge background color. | `"custom" \| "green" \| "neutral" \| "red" \| "yellow"` | `'neutral'` |
 
 
 ## Slots

--- a/src/components/beta/gux-badge/readme.md
+++ b/src/components/beta/gux-badge/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property | Attribute | Description             | Type                                                    | Default     |
-| -------- | --------- | ----------------------- | ------------------------------------------------------- | ----------- |
-| `bold`   | `bold`    | Bold badge.             | `boolean`                                               | `false`     |
-| `color`  | `color`   | Badge background color. | `"custom" \| "green" \| "neutral" \| "red" \| "yellow"` | `'neutral'` |
+| Property | Attribute | Description             | Type                                                     | Default     |
+| -------- | --------- | ----------------------- | -------------------------------------------------------- | ----------- |
+| `bold`   | `bold`    | Bold badge.             | `boolean`                                                | `false`     |
+| `color`  | `color`   | Badge background color. | `"green" \| "inherit" \| "neutral" \| "red" \| "yellow"` | `'neutral'` |
 
 
 ## Slots

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.e2e.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.e2e.ts.snap
@@ -31,3 +31,7 @@ exports[`gux-badge-beta #render should render component as expected (14) 1`] = `
 exports[`gux-badge-beta #render should render component as expected (15) 1`] = `"<gux-badge-beta bold=\\"\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>default bold</gux-badge-beta>"`;
 
 exports[`gux-badge-beta #render should render component as expected (16) 1`] = `"<gux-badge-beta bold=\\"\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>default bold icon</gux-badge-beta>"`;
+
+exports[`gux-badge-beta #render should render component as expected (17) 1`] = `"<gux-badge-beta color=\\"custom\\" class=\\"custom\\" hydrated=\\"\\">custom</gux-badge-beta>"`;
+
+exports[`gux-badge-beta #render should render component as expected (18) 1`] = `"<gux-badge-beta color=\\"custom\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>custom with icon</gux-badge-beta>"`;

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.e2e.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.e2e.ts.snap
@@ -32,6 +32,6 @@ exports[`gux-badge-beta #render should render component as expected (15) 1`] = `
 
 exports[`gux-badge-beta #render should render component as expected (16) 1`] = `"<gux-badge-beta bold=\\"\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>default bold icon</gux-badge-beta>"`;
 
-exports[`gux-badge-beta #render should render component as expected (17) 1`] = `"<gux-badge-beta color=\\"custom\\" class=\\"custom\\" hydrated=\\"\\">custom</gux-badge-beta>"`;
+exports[`gux-badge-beta #render should render component as expected (17) 1`] = `"<gux-badge-beta color=\\"inherit\\" hydrated=\\"\\">inherit</gux-badge-beta>"`;
 
-exports[`gux-badge-beta #render should render component as expected (18) 1`] = `"<gux-badge-beta color=\\"custom\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>custom with icon</gux-badge-beta>"`;
+exports[`gux-badge-beta #render should render component as expected (18) 1`] = `"<gux-badge-beta color=\\"inherit\\" hydrated=\\"\\"><gux-icon icon-name=\\"subtract\\" decorative=\\"\\" hydrated=\\"\\"></gux-icon>inherit with icon</gux-badge-beta>"`;

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
@@ -297,7 +297,7 @@ exports[`gux-badge-beta #render should render component as expected (16) 1`] = `
 `;
 
 exports[`gux-badge-beta #render should render component as expected (17) 1`] = `
-<gux-badge-beta class="custom" color="custom">
+<gux-badge-beta color="custom">
   <mock:shadow-root>
     <div class="gux-badge gux-custom">
       <gux-tooltip-title>
@@ -305,7 +305,9 @@ exports[`gux-badge-beta #render should render component as expected (17) 1`] = `
           <slot aria-hidden="true"></slot>
         </span>
       </gux-tooltip-title>
-      <div class="gux-sr-only"></div>
+      <div class="gux-sr-only">
+        badge with label: , color: custom
+      </div>
     </div>
   </mock:shadow-root>
   custom
@@ -321,7 +323,9 @@ exports[`gux-badge-beta #render should render component as expected (18) 1`] = `
           <slot aria-hidden="true"></slot>
         </span>
       </gux-tooltip-title>
-      <div class="gux-sr-only"></div>
+      <div class="gux-sr-only">
+        badge with label: , color: custom
+      </div>
     </div>
   </mock:shadow-root>
   <gux-icon decorative="" icon-name="subtract"></gux-icon>

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
@@ -306,7 +306,7 @@ exports[`gux-badge-beta #render should render component as expected (17) 1`] = `
         </span>
       </gux-tooltip-title>
       <div class="gux-sr-only">
-        badge with label: , color: inherited
+        badge with label:
       </div>
     </div>
   </mock:shadow-root>
@@ -324,7 +324,7 @@ exports[`gux-badge-beta #render should render component as expected (18) 1`] = `
         </span>
       </gux-tooltip-title>
       <div class="gux-sr-only">
-        badge with label: , color: inherited
+        badge with label:
       </div>
     </div>
   </mock:shadow-root>

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
@@ -297,38 +297,38 @@ exports[`gux-badge-beta #render should render component as expected (16) 1`] = `
 `;
 
 exports[`gux-badge-beta #render should render component as expected (17) 1`] = `
-<gux-badge-beta color="custom">
+<gux-badge-beta color="inherit">
   <mock:shadow-root>
-    <div class="gux-badge gux-custom">
+    <div class="gux-badge gux-inherit">
       <gux-tooltip-title>
         <span>
           <slot aria-hidden="true"></slot>
         </span>
       </gux-tooltip-title>
       <div class="gux-sr-only">
-        badge with label: , color: custom
+        badge with label: , color: inherited
       </div>
     </div>
   </mock:shadow-root>
-  custom
+  inherit
 </gux-badge-beta>
 `;
 
 exports[`gux-badge-beta #render should render component as expected (18) 1`] = `
-<gux-badge-beta color="custom">
+<gux-badge-beta color="inherit">
   <mock:shadow-root>
-    <div class="gux-badge gux-custom">
+    <div class="gux-badge gux-inherit">
       <gux-tooltip-title>
         <span>
           <slot aria-hidden="true"></slot>
         </span>
       </gux-tooltip-title>
       <div class="gux-sr-only">
-        badge with label: , color: custom
+        badge with label: , color: inherited
       </div>
     </div>
   </mock:shadow-root>
   <gux-icon decorative="" icon-name="subtract"></gux-icon>
-  custom with icon
+  inherit with icon
 </gux-badge-beta>
 `;

--- a/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
+++ b/src/components/beta/gux-badge/tests/__snapshots__/gux-badge.spec.ts.snap
@@ -295,3 +295,36 @@ exports[`gux-badge-beta #render should render component as expected (16) 1`] = `
   default bold icon
 </gux-badge-beta>
 `;
+
+exports[`gux-badge-beta #render should render component as expected (17) 1`] = `
+<gux-badge-beta class="custom" color="custom">
+  <mock:shadow-root>
+    <div class="gux-badge gux-custom">
+      <gux-tooltip-title>
+        <span>
+          <slot aria-hidden="true"></slot>
+        </span>
+      </gux-tooltip-title>
+      <div class="gux-sr-only"></div>
+    </div>
+  </mock:shadow-root>
+  custom
+</gux-badge-beta>
+`;
+
+exports[`gux-badge-beta #render should render component as expected (18) 1`] = `
+<gux-badge-beta color="custom">
+  <mock:shadow-root>
+    <div class="gux-badge gux-custom">
+      <gux-tooltip-title>
+        <span>
+          <slot aria-hidden="true"></slot>
+        </span>
+      </gux-tooltip-title>
+      <div class="gux-sr-only"></div>
+    </div>
+  </mock:shadow-root>
+  <gux-icon decorative="" icon-name="subtract"></gux-icon>
+  custom with icon
+</gux-badge-beta>
+`;

--- a/src/components/beta/gux-badge/tests/gux-badge.e2e.ts
+++ b/src/components/beta/gux-badge/tests/gux-badge.e2e.ts
@@ -19,8 +19,8 @@ describe('gux-badge-beta', () => {
       '<gux-badge-beta bold color="yellow"><gux-icon icon-name="subtract" decorative></gux-icon>warning bold icon</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>',
-      '<gux-badge-beta color="custom" class="custom">custom</gux-badge-beta>',
-      '<gux-badge-beta color="custom"><gux-icon icon-name="subtract" decorative></gux-icon>custom with icon</gux-badge-beta>'
+      '<gux-badge-beta color="inherit">inherit</gux-badge-beta>',
+      '<gux-badge-beta color="inherit"><gux-icon icon-name="subtract" decorative></gux-icon>inherit with icon</gux-badge-beta>'
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSparkE2EPage({ html });

--- a/src/components/beta/gux-badge/tests/gux-badge.e2e.ts
+++ b/src/components/beta/gux-badge/tests/gux-badge.e2e.ts
@@ -18,7 +18,9 @@ describe('gux-badge-beta', () => {
       '<gux-badge-beta bold color="red"><gux-icon icon-name="subtract" decorative></gux-icon>danger bold icon</gux-badge-beta>',
       '<gux-badge-beta bold color="yellow"><gux-icon icon-name="subtract" decorative></gux-icon>warning bold icon</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold</gux-badge-beta>',
-      '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>'
+      '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>',
+      '<gux-badge-beta color="custom" class="custom">custom</gux-badge-beta>',
+      '<gux-badge-beta color="custom"><gux-icon icon-name="subtract" decorative></gux-icon>custom with icon</gux-badge-beta>'
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSparkE2EPage({ html });

--- a/src/components/beta/gux-badge/tests/gux-badge.spec.ts
+++ b/src/components/beta/gux-badge/tests/gux-badge.spec.ts
@@ -22,7 +22,9 @@ describe('gux-badge-beta', () => {
       '<gux-badge-beta bold color="red"><gux-icon icon-name="subtract" decorative></gux-icon>danger bold icon</gux-badge-beta>',
       '<gux-badge-beta bold color="yellow"><gux-icon icon-name="subtract" decorative></gux-icon>warning bold icon</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold</gux-badge-beta>',
-      '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>'
+      '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>',
+      '<gux-badge-beta color="custom">custom</gux-badge-beta>',
+      '<gux-badge-beta color="custom"><gux-icon icon-name="subtract" decorative></gux-icon>custom with icon</gux-badge-beta>'
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });

--- a/src/components/beta/gux-badge/tests/gux-badge.spec.ts
+++ b/src/components/beta/gux-badge/tests/gux-badge.spec.ts
@@ -23,8 +23,8 @@ describe('gux-badge-beta', () => {
       '<gux-badge-beta bold color="yellow"><gux-icon icon-name="subtract" decorative></gux-icon>warning bold icon</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold</gux-badge-beta>',
       '<gux-badge-beta bold><gux-icon icon-name="subtract" decorative></gux-icon>default bold icon</gux-badge-beta>',
-      '<gux-badge-beta color="custom">custom</gux-badge-beta>',
-      '<gux-badge-beta color="custom"><gux-icon icon-name="subtract" decorative></gux-icon>custom with icon</gux-badge-beta>'
+      '<gux-badge-beta color="inherit">inherit</gux-badge-beta>',
+      '<gux-badge-beta color="inherit"><gux-icon icon-name="subtract" decorative></gux-icon>inherit with icon</gux-badge-beta>'
     ].forEach((html, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSpecPage({ components, html, language });

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -14,7 +14,7 @@
     "yellow-bold": "badge with label: {label}, color: yellow bold",
     "red": "badge with label: {label}, color: red",
     "red-bold": "badge with label: {label}, color: red bold",
-    "custom": "badge with label: {label}, color: custom"
+    "inherit": "badge with label: {label}, color: inherited"
   },
   "gux-column-manager-item": {
     "activateReordering": "Activate reordering mode for {columnName} column"

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -13,7 +13,8 @@
     "yellow": "badge with label: {label}, color: yellow",
     "yellow-bold": "badge with label: {label}, color: yellow bold",
     "red": "badge with label: {label}, color: red",
-    "red-bold": "badge with label: {label}, color: red bold"
+    "red-bold": "badge with label: {label}, color: red bold",
+    "custom": "badge with label: {label}, color: custom"
   },
   "gux-column-manager-item": {
     "activateReordering": "Activate reordering mode for {columnName} column"


### PR DESCRIPTION
In some cases, designers need to create custom badges where they have a status where the existing colors are not appropriate & they need to differentiate labels.

I've added a new color prop value (custom), to guard against the accidental overriding of existing colors & used the custom properties override pattern used in the input margins.