### PR TITLE
fix(dropdown-multi): prevent text from overlapping

### DIFF
--- a/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.less
+++ b/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.less
@@ -81,6 +81,7 @@
       .gux-filter-input {
         all: unset;
         width: 100%;
+        color: transparent;
         caret-color: @gux-black-50;
       }
 


### PR DESCRIPTION
**Description**
Prevent text from overlapping in dropdown-multi when `filterable` or `filter-type` are applied.

[COMUI-1510](https://inindca.atlassian.net/browse/COMUI-1510)

[COMUI-1510]: https://inindca.atlassian.net/browse/COMUI-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ