### PR TITLE
feat(icon): better autocomplete for iconName

### DIFF
--- a/src/components/stable/gux-icon/gux-icon.tsx
+++ b/src/components/stable/gux-icon/gux-icon.tsx
@@ -25,7 +25,10 @@ export class GuxIcon {
    * Indicate which icon to display
    */
   @Prop()
-  iconName: string | GuxIconIconName;
+  // Using (string & {}) preserves autocomplete, otherwise TS collapses this type to just `string`
+  // See https://github.com/microsoft/TypeScript/issues/49220
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  iconName: (string & {}) | GuxIconIconName;
 
   /**
    * Indicate whether the icon should be ignored by accessibility tools or not


### PR DESCRIPTION
Currently TS consumers don't really get autocomplete on iconName because it's effectively just `iconName: string`.  This use a slight TS hack to work around it.  Linked [Typescript/#49220](https://github.com/microsoft/TypeScript/issues/49220) - which may eventually provide a non-hacky fix via JSDoc comment.  (But that PR has been open for almost a year, so I'm not holding my breath)