### PR TITLE
Aligning icon and text in copy to clipboard tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19506,7 +19506,7 @@
       }
     },
     "packages/genesys-spark-components": {
-      "version": "3.70.1",
+      "version": "3.70.2",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.2.0",
@@ -19585,7 +19585,7 @@
       }
     },
     "packages/genesys-spark-components-react": {
-      "version": "3.70.1",
+      "version": "3.70.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^17.0.37",
@@ -19751,7 +19751,7 @@
       }
     },
     "web-apps/genesys-spark-examples": {
-      "version": "3.70.1",
+      "version": "3.70.2",
       "license": "MIT",
       "dependencies": {
         "genesys-spark-components": "file:../../packages/genesys-spark-components",

--- a/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/gux-copy-to-clipboard.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/gux-copy-to-clipboard.less
@@ -43,10 +43,15 @@ button {
     display: inline-flex;
     align-items: center;
 
+    &.tooltip-text {
+      vertical-align: middle;
+    }
+
     gux-icon {
       width: 16px;
       height: 16px;
       padding-right: @gux-spacing-xs;
+      vertical-align: middle;
 
       &[icon-name='badge-check'] {
         color: @gux-alert-green-60;

--- a/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/gux-copy-to-clipboard.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/gux-copy-to-clipboard.tsx
@@ -2,6 +2,7 @@ import { Component, Element, h, JSX, State, Listen } from '@stencil/core';
 import { trackComponent } from '@utils/tracking/usage';
 import { buildI18nForComponent, GetI18nValue } from '../../../i18n';
 import translationResources from './i18n/en.json';
+import { TooltipContentType } from './tooltip-content-type';
 
 /**
  * @slot content - Slot for content
@@ -19,7 +20,7 @@ export class GuxCopyToClipboard {
   private root: HTMLElement;
 
   @State()
-  tooltipContent: string = 'offerClick';
+  tooltipContent: string = 'clickToCopy' as TooltipContentType;
 
   @Listen('mouseleave')
   onMouseleave() {
@@ -34,11 +35,11 @@ export class GuxCopyToClipboard {
   @Listen('focus')
   onFocus() {
     // when element is focused by keyboard
-    this.tooltipContent = 'offerEnter';
+    this.tooltipContent = 'enterToCopy';
   }
 
   private resetTooltip() {
-    this.tooltipContent = 'offerClick';
+    this.tooltipContent = 'clickToCopy';
   }
 
   private onCopyToClipboard() {
@@ -47,11 +48,44 @@ export class GuxCopyToClipboard {
     navigator.clipboard
       .writeText(copyText)
       .then(() => {
-        this.tooltipContent = 'success';
+        this.tooltipContent = 'copySuccess';
       })
       .catch(() => {
-        this.tooltipContent = 'error';
+        this.tooltipContent = 'copyFailure';
       });
+  }
+
+  private renderTooltipIcon(): JSX.Element {
+    let iconName;
+
+    switch (this.tooltipContent) {
+      case 'copyFailure':
+        iconName = 'badge-x';
+        break;
+      case 'copySuccess':
+        iconName = 'badge-check';
+        break;
+      default:
+        iconName = null;
+        break;
+    }
+
+    if (!iconName) return null;
+
+    return (
+      <gux-icon icon-name={iconName} decorative></gux-icon>
+    ) as JSX.Element;
+  }
+
+  private renderTooltip(): JSX.Element {
+    return (
+      <gux-tooltip placement="bottom-end">
+        <div class="gux-tooltip-markup">
+          {this.renderTooltipIcon()}
+          <span class="tooltip-text">{this.i18n(this.tooltipContent)}</span>
+        </div>
+      </gux-tooltip>
+    ) as JSX.Element;
   }
 
   async componentWillLoad(): Promise<void> {
@@ -70,25 +104,7 @@ export class GuxCopyToClipboard {
           <slot name="content" />
           <gux-icon icon-name="copy" decorative></gux-icon>
         </div>
-        <gux-tooltip placement="bottom-end">
-          {/* Icon */}
-          {this.tooltipContent === 'success' ? (
-            <gux-icon icon-name="badge-check" decorative></gux-icon>
-          ) : (
-            ''
-          )}
-          {this.tooltipContent === 'error' ? (
-            <gux-icon icon-name="badge-x" decorative></gux-icon>
-          ) : (
-            ''
-          )}
-
-          {/* Tooltip Text */}
-          {this.tooltipContent === 'offerClick' ? this.i18n('clickToCopy') : ''}
-          {this.tooltipContent === 'offerEnter' ? this.i18n('enterToCopy') : ''}
-          {this.tooltipContent === 'success' ? this.i18n('copySuccess') : ''}
-          {this.tooltipContent === 'error' ? this.i18n('copyFailure') : ''}
-        </gux-tooltip>
+        {this.renderTooltip()}
       </button>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tests/__snapshots__/gux-copy-to-clipboard.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tests/__snapshots__/gux-copy-to-clipboard.spec.ts.snap
@@ -9,7 +9,11 @@ exports[`gux-copy-to-clipboard-beta #render should render copy to clipboard 1`] 
         <gux-icon decorative="" icon-name="copy"></gux-icon>
       </div>
       <gux-tooltip placement="bottom-end">
-        Click to Copy
+        <div class="gux-tooltip-markup">
+          <span class="tooltip-text">
+            Click to Copy
+          </span>
+        </div>
       </gux-tooltip>
     </button>
   </mock:shadow-root>

--- a/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tests/gux-copy-to-clipboard.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tests/gux-copy-to-clipboard.spec.ts
@@ -49,7 +49,7 @@ describe('gux-copy-to-clipboard-beta', () => {
       component.onCopyToClipboard();
       await page.waitForChanges();
 
-      expect(component.tooltipContent).toEqual('success');
+      expect(component.tooltipContent).toEqual('copySuccess');
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled();
     });
 
@@ -66,7 +66,7 @@ describe('gux-copy-to-clipboard-beta', () => {
       component.onCopyToClipboard();
       await page.waitForChanges();
 
-      expect(component.tooltipContent).toEqual('error');
+      expect(component.tooltipContent).toEqual('copyFailure');
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled();
     });
   });

--- a/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tooltip-content-type.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-copy-to-clipboard/tooltip-content-type.ts
@@ -1,0 +1,7 @@
+export type TooltipContentType =
+  | 'copySuccess'
+  | 'error'
+  | 'clickToCopy'
+  | 'enterToCopy'
+  | 'copyFailure'
+  | 'copyToClipboard';


### PR DESCRIPTION
Ticket to reference: https://inindca.atlassian.net/browse/COMUI-1573

Before:
<img width="494" alt="Screen Shot 2023-03-15 at 2 35 37 PM" src="https://user-images.githubusercontent.com/127438502/225409219-efec48da-1cf4-4305-a348-6aa9ff19697a.png">

After:
<img width="395" alt="Screen Shot 2023-03-15 at 2 34 14 PM" src="https://user-images.githubusercontent.com/127438502/225408979-410b40ea-943d-4ae6-ace3-30606f0bf25a.png">
