### PR TITLE
fix(dropdown): use margin for spacing beside gux-option-icon icon

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/options/gux-option-icon/gux-option-icon.less
@@ -6,14 +6,14 @@ gux-option-icon {
 
   .gux-option-defaults();
 
-  align-items: top;
+  align-items: flex-start;
 
   gux-icon {
     flex-shrink: 0;
     width: @icon-size;
     height: @icon-size;
-    padding-right: @gux-spacing-xs;
-    // This & align-items: top; ensures the icon is centered on the first line of text
-    margin-top: calc((@line-height - @icon-size) / 2);
+    // This & align-items: flex-start; ensures the icon is centered on the first line of text
+    margin-block-start: calc((@line-height - @icon-size) / 2);
+    margin-inline-end: @gux-spacing-xs;
   }
 }


### PR DESCRIPTION
Updates `gux-option-icon` styling to use margin instead of padding for the space between the icon and the text since the icon's width is assumed not to include that spacing but that's not the case if the icon has `box-sizing: border-box`.

https://inindca.atlassian.net/browse/COMUI-1612