### PR TITLE
feat(toggle): make gux-toggle-slider a flexbox

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle-slider/gux-toggle-slider.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-toggle/gux-toggle-slider/gux-toggle-slider.less
@@ -8,6 +8,8 @@
 @slider-transition-duration: 0.5s;
 
 gux-toggle-slider {
+  display: flex;
+  align-items: center;
   padding: 2px;
   outline: none;
 


### PR DESCRIPTION
The existing toggle slider is built to be a flexbox but isn't assigned as one. The fact that it _isn't_ a flexbox means that the appropriate vertical alignment of its children are vulnerable to host document root styling. That kind of layout issue can be hard to track down.