### PR TITLE
fix(calendar): align tables flush to start of container

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
@@ -68,6 +68,7 @@
 
   .gux-content {
     display: flex;
+    align-items: flex-start;
     padding: 20px 24px;
     color: @gux-black-50;
     background-color: @gux-grey-100;


### PR DESCRIPTION
Align tables flush to start of container.

[COMUI-1579](https://inindca.atlassian.net/browse/COMUI-1579)

[COMUI-1579]: https://inindca.atlassian.net/browse/COMUI-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ