### PR TITLE
fix(gux-time-picker): restore :focus-within focus styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea/
 .vscode/
 node_modules/

--- a/packages/genesys-spark-components/src/components/beta/gux-time-picker/gux-time-picker.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-time-picker/gux-time-picker.less
@@ -36,19 +36,9 @@
     border-radius: 4px;
     box-shadow: inset 0 0 4px fade(@gux-black-30, 16%);
 
-    .gux-input-time-container {
-      border-radius: 2px;
-
-      &:has(:focus-visible) {
-        .gux-focus-ring();
-      }
-
-      // We want to fallback to browsers that do not support the :has selector, such as Firefox
-      @supports not selector(:has(:focus-visible)) {
-        &:focus-within {
-          .gux-focus-ring();
-        }
-      }
+    &:focus-within {
+      border-color: @gux-blue-60;
+      .gux-focus-ring();
     }
 
     input {


### PR DESCRIPTION
Restores the prior `:focus-within` based focus styling for gux-time-picker component. This matches the behavior of gux-form-field-text-like, which is a conceptually similar component to time picker.

https://inindca.atlassian.net/browse/COMUI-1611