### PR TITLE
fix(tab-advanced-list): allow drag scrolling

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tabs-advanced/gux-tab-advanced-list/gux-tab-advanced-list.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tabs-advanced/gux-tab-advanced-list/gux-tab-advanced-list.tsx
@@ -620,6 +620,7 @@ export class GuxTabAdvancedList {
             title={this.i18n(direction)}
             aria-label={this.i18n(direction)}
             class="gux-scroll-button"
+            onDragOver={() => this.getScrollDirection(direction)}
             onClick={() => this.getScrollDirection(direction)}
           >
             <gux-icon


### PR DESCRIPTION
allow scrolling if dragged element is over scroll button.

This implementation is based on how I think it should work. There currently is no guidance on how it should work.

COMUI-1693