### PR TITLE
fix(table-toolbar): addition of tooltip when actions are in icon-only mode.

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-action/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-action/readme.md
@@ -27,6 +27,7 @@
 graph TD;
   gux-table-toolbar-action --> gux-table-toolbar-custom-action
   gux-table-toolbar-action --> gux-icon
+  gux-table-toolbar-custom-action --> gux-tooltip
   gux-table-toolbar-custom-action --> gux-button-slot-beta
   style gux-table-toolbar-action fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/gux-table-toolbar-custom-action.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, JSX, h, Prop } from '@stencil/core';
 import { trackComponent } from '@utils/tracking/usage';
 import { GuxTableToolbarActionAccent } from '../gux-table-toolbar-action-accents.types';
-
+import { getSlotTextContent } from '@utils/dom/get-slot-text-content';
 /**
  * @slot text - Slot for action text.
  * @slot icon - Slot for icon.
@@ -25,6 +25,14 @@ export class GuxTableToolbarCustomAction {
   @Prop()
   disabled: boolean = false;
 
+  private renderTooltip(): JSX.Element {
+    if (this.iconOnly) {
+      return (
+        <gux-tooltip>{getSlotTextContent(this.root, 'text')}</gux-tooltip>
+      ) as JSX.Element;
+    }
+  }
+
   componentWillLoad() {
     trackComponent(this.root);
   }
@@ -38,6 +46,7 @@ export class GuxTableToolbarCustomAction {
             <slot name="text" />
           </span>
         </button>
+        {this.renderTooltip()}
       </gux-button-slot-beta>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-custom-action/readme.md
@@ -30,11 +30,13 @@
 
 ### Depends on
 
+- [gux-tooltip](../../../stable/gux-tooltip)
 - [gux-button-slot-beta](../../gux-button-slot)
 
 ### Graph
 ```mermaid
 graph TD;
+  gux-table-toolbar-custom-action --> gux-tooltip
   gux-table-toolbar-custom-action --> gux-button-slot-beta
   gux-table-toolbar-action --> gux-table-toolbar-custom-action
   style gux-table-toolbar-custom-action fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/gux-table-toolbar-menu-button.tsx
@@ -23,6 +23,7 @@ import { afterNextRender } from '../../../../utils/dom/after-next-render';
 export class GuxTableToolbarMenuButton {
   listElement: HTMLGuxListElement;
   dropdownButton: HTMLElement;
+  private tooltipTitleElement: HTMLGuxTooltipTitleElement;
 
   private i18n: GetI18nValue;
 
@@ -79,6 +80,16 @@ export class GuxTableToolbarMenuButton {
     }
   }
 
+  @Listen('focusin')
+  onFocusin() {
+    void this.tooltipTitleElement.setShowTooltip();
+  }
+
+  @Listen('focusout')
+  onFocusout() {
+    void this.tooltipTitleElement.setHideTooltip();
+  }
+
   private toggle(): void {
     this.expanded = !this.expanded;
     if (this.expanded) {
@@ -121,10 +132,14 @@ export class GuxTableToolbarMenuButton {
                 aria-haspopup="true"
                 aria-expanded={this.expanded.toString()}
               >
-                <gux-icon
-                  screenreader-text={this.i18n('additionalActions')}
-                  icon-name="menu-kebab-horizontal"
-                ></gux-icon>
+                <gux-tooltip-title ref={el => (this.tooltipTitleElement = el)}>
+                  <span>
+                    <gux-icon
+                      screenreader-text={this.i18n('additionalActions')}
+                      icon-name="menu-kebab-horizontal"
+                    ></gux-icon>
+                  </span>
+                </gux-tooltip-title>
               </button>
             </gux-button-slot-beta>
           </div>

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/gux-table-toolbar-menu-button/readme.md
@@ -22,6 +22,7 @@
 
 - [gux-popup-beta](../../gux-popup-beta)
 - [gux-button-slot-beta](../../gux-button-slot)
+- [gux-tooltip-title](../../../stable/gux-tooltip-title)
 - [gux-icon](../../../stable/gux-icon)
 - [gux-list](../../../stable/gux-list)
 
@@ -30,8 +31,10 @@
 graph TD;
   gux-table-toolbar-menu-button --> gux-popup-beta
   gux-table-toolbar-menu-button --> gux-button-slot-beta
+  gux-table-toolbar-menu-button --> gux-tooltip-title
   gux-table-toolbar-menu-button --> gux-icon
   gux-table-toolbar-menu-button --> gux-list
+  gux-tooltip-title --> gux-tooltip
   gux-table-toolbar-beta --> gux-table-toolbar-menu-button
   style gux-table-toolbar-menu-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/readme.md
@@ -28,8 +28,10 @@ graph TD;
   gux-table-toolbar-beta --> gux-table-toolbar-menu-button
   gux-table-toolbar-menu-button --> gux-popup-beta
   gux-table-toolbar-menu-button --> gux-button-slot-beta
+  gux-table-toolbar-menu-button --> gux-tooltip-title
   gux-table-toolbar-menu-button --> gux-icon
   gux-table-toolbar-menu-button --> gux-list
+  gux-tooltip-title --> gux-tooltip
   style gux-table-toolbar-beta fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-table-toolbar/tests/__snapshots__/gux-table-toolbar.spec.ts.snap
@@ -19,7 +19,11 @@ exports[`gux-table-toolbar-beta #render should render table toolbar as expected 
               <div class="gux-toolbar-menu-container" slot="target">
                 <gux-button-slot-beta class="gux-menu-button">
                   <button aria-expanded="false" aria-haspopup="true" type="button">
-                    <gux-icon icon-name="menu-kebab-horizontal" screenreader-text="Additional Actions"></gux-icon>
+                    <gux-tooltip-title>
+                      <span>
+                        <gux-icon icon-name="menu-kebab-horizontal" screenreader-text="Additional Actions"></gux-icon>
+                      </span>
+                    </gux-tooltip-title>
                   </button>
                 </gux-button-slot-beta>
               </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip-title/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip-title/readme.md
@@ -35,6 +35,7 @@ Type: `Promise<void>`
  - [gux-badge-beta](../../beta/gux-badge)
  - [gux-tab](../gux-tabs/gux-tab)
  - [gux-tab-advanced](../gux-tabs-advanced/gux-tab-advanced)
+ - [gux-table-toolbar-menu-button](../../beta/gux-table-toolbar/gux-table-toolbar-menu-button)
  - [gux-tag-beta](../../beta/gux-tag)
 
 ### Depends on
@@ -48,6 +49,7 @@ graph TD;
   gux-badge-beta --> gux-tooltip-title
   gux-tab --> gux-tooltip-title
   gux-tab-advanced --> gux-tooltip-title
+  gux-table-toolbar-menu-button --> gux-tooltip-title
   gux-tag-beta --> gux-tooltip-title
   style gux-tooltip-title fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip/readme.md
@@ -67,6 +67,7 @@ Type: `Promise<void>`
 
  - [gux-copy-to-clipboard-beta](../../beta/gux-copy-to-clipboard)
  - [gux-pagination-ellipsis-button](../../beta/gux-pagination-beta/gux-pagination-buttons-beta/gux-pagination-ellipsis-button)
+ - [gux-table-toolbar-custom-action](../../beta/gux-table-toolbar/gux-table-toolbar-custom-action)
  - [gux-tooltip-title](../gux-tooltip-title)
  - [gux-truncate-beta](../../beta/gux-truncate)
 
@@ -75,6 +76,7 @@ Type: `Promise<void>`
 graph TD;
   gux-copy-to-clipboard-beta --> gux-tooltip
   gux-pagination-ellipsis-button --> gux-tooltip
+  gux-table-toolbar-custom-action --> gux-tooltip
   gux-tooltip-title --> gux-tooltip
   gux-truncate-beta --> gux-tooltip
   style gux-tooltip fill:#f9f,stroke:#333,stroke-width:4px


### PR DESCRIPTION
addition of tooltip when actions are in icon-only state

[COMUI-1713](https://inindca.atlassian.net/browse/COMUI-1713)

I was not sure about the `menu-actions` button should that always have a tooltip since it technically is always just an icon.
I opted for the `menu-actions` to always have a tooltip.

[COMUI-1713]: https://inindca.atlassian.net/browse/COMUI-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ