### PR TITLE
fix(icon): don't await cached icon fetch promises

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-icon/gux-icon.service.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/gux-icon.service.ts
@@ -37,10 +37,9 @@ export function getRootIconName(iconName: string): string {
 
 export async function getBaseSvgHtml(iconName: string): Promise<string> {
   const id = iconInfoToId(iconName);
-  const cachedSvgElement = await svgHTMLCache.get(id);
 
-  if (cachedSvgElement) {
-    return cachedSvgElement;
+  if (svgHTMLCache.has(id)) {
+    return svgHTMLCache.get(id);
   }
 
   const svgHtml = fetchIcon(iconName)

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/tests/gux-icon.service.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/tests/gux-icon.service.spec.ts
@@ -1,0 +1,25 @@
+import { getBaseSvgHtml } from '../gux-icon.service';
+
+describe('icon.service', () => {
+  let fetchSpy: jest.SpyInstance;
+  beforeEach(() => {
+    const svgResponse = new Response(
+      '<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M8 16C12.4187 16 16 12.4187 16 8C16 3.58125 12.4187 0 8 0C3.58125 0 0 3.58125 0 8C0 12.4187 3.58125 16 8 16Z"/></svg>'
+    );
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(svgResponse);
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  describe('getBaseSvgHtml', () => {
+    it('should only fetch once if the same icon is requested multiple times', () => {
+      return Promise.all([
+        getBaseSvgHtml('test'),
+        getBaseSvgHtml('test'),
+        getBaseSvgHtml('test')
+      ]).finally(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes an issue that caused the icon fetch caching to not actually coalesce multiple simultaneous calls via getBaseSvgHtml() to a single fetch request, because the logic that retrieved the cached fetch promise awaited that promise instead of returning it immediately.

https://inindca.atlassian.net/browse/COMUI-1723