### PR TITLE
fix(gux-popup-beta): hide popup when target element goes out of view

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.less
@@ -1,5 +1,6 @@
 @import (reference) '../../../style/color.less';
 @import (reference) '../../../style/zindex.less';
+@import (reference) '../../../style/typography.less';
 
 .gux-target-container {
   &.gux-disabled {
@@ -18,4 +19,8 @@
   &.gux-expanded {
     visibility: visible;
   }
+}
+
+.gux-sr-only-clip {
+  .gux-sr-only-clip();
 }

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
@@ -15,7 +15,8 @@ import {
   MiddlewareArguments,
   offset,
   size,
-  shift
+  shift,
+  hide
 } from '@floating-ui/dom';
 
 /**
@@ -87,14 +88,20 @@ export class GuxPopupBeta {
                 });
               }
             }),
-            shift()
+            shift(),
+            hide()
           ]
         }
-      ).then(({ x, y }) => {
+      ).then(({ x, y, middlewareData }) => {
+        const { referenceHidden } = middlewareData.hide;
+
         Object.assign(this.popupElementContainer.style, {
           left: `${x}px`,
           top: `${y}px`
         });
+        referenceHidden
+          ? this.popupElementContainer.classList.add('gux-sr-only-clip')
+          : this.popupElementContainer.classList.remove('gux-sr-only-clip');
       });
     }
   }


### PR DESCRIPTION
hide popup element when target element goes out of view.

**Notes**
When implementing this  `floating-ui` uses the `visibility` css property to show and hide the popup container when its goes out of view and comes back into the view. We are also using the `visibility` property within our css for when the user clicks on the target element which causes the `visibility` in the css to be overridden.

The cleanest solution I could think of without causing breakages was to just set the styling through javascript and apply the stying in the necessary places.

Also this change will affect other components which use `popup-beta`

[COMUI-1712](https://inindca.atlassian.net/browse/COMUI-1712)

[COMUI-1712]: https://inindca.atlassian.net/browse/COMUI-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ