### PR TITLE
chore(jenkinsfile): add email and chat notification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,8 @@ Boolean isPublicBranch = isReleaseBranch || isFeatureBranch
 webappPipeline {
     projectName = 'spark-components'
     team = 'Core UI'
-    mailer = 'CoreUI@genesys.com'
+    mailer = 'matthew.cheely@genesys.com, daragh.king@genesys.com, jordan.stith@genesys.com, thomas.dillon@genesys.com, katie.bobbe@genesys.com, gavin.everett@genesys.com, jason.evans@genesys.com'
+    chatGroupId='adhoc-30ab1aa8-d42e-4590-b2a4-c9f7cef6d51c'
     nodeVersion = '16.18.0'
     testJob = 'no-tests'
     deployConfig = [:]

--- a/jenkinsfiles/components.Jenkinsfile
+++ b/jenkinsfiles/components.Jenkinsfile
@@ -23,7 +23,8 @@ def isPublicBranch = {
 webappPipeline {
     projectName = 'spark-components'
     team = 'Core UI'
-    mailer = 'CoreUI@genesys.com'
+    mailer = 'matthew.cheely@genesys.com, daragh.king@genesys.com, jordan.stith@genesys.com, thomas.dillon@genesys.com, katie.bobbe@genesys.com, gavin.everett@genesys.com, jason.evans@genesys.com'
+    chatGroupId='adhoc-30ab1aa8-d42e-4590-b2a4-c9f7cef6d51c'
     nodeVersion = '16.18.0'
     testJob = 'no-tests'
     deployConfig = [:]

--- a/jenkinsfiles/docs.Jenkinsfile
+++ b/jenkinsfiles/docs.Jenkinsfile
@@ -27,7 +27,8 @@ def isPublicBranch = {
 webappPipeline {
     projectName = 'common-ui-docs/genesys-webcomponents'
     team = 'Core UI'
-    mailer = 'CoreUI@genesys.com'
+    mailer = 'matthew.cheely@genesys.com, daragh.king@genesys.com, jordan.stith@genesys.com, thomas.dillon@genesys.com, katie.bobbe@genesys.com, gavin.everett@genesys.com, jason.evans@genesys.com'
+    chatGroupId='adhoc-30ab1aa8-d42e-4590-b2a4-c9f7cef6d51c'
     nodeVersion = '16.18.0'
     testJob = 'no-tests'
     deployConfig = [dev : 'always']

--- a/web-apps/genesys-spark-examples/Jenkinsfile
+++ b/web-apps/genesys-spark-examples/Jenkinsfile
@@ -11,7 +11,8 @@ Boolean isReleaseBranch = isMainBranch || isMaintenanceReleaseBranch
 webappPipeline {
     projectName = 'common-ui-docs/genesys-webcomponents'
     team = 'Core UI'
-    mailer = 'CoreUI@genesys.com'
+    mailer = 'matthew.cheely@genesys.com, daragh.king@genesys.com, jordan.stith@genesys.com, thomas.dillon@genesys.com, katie.bobbe@genesys.com, gavin.everett@genesys.com, jason.evans@genesys.com'
+    chatGroupId='adhoc-30ab1aa8-d42e-4590-b2a4-c9f7cef6d51c'
     nodeVersion = '16.18.0'
     testJob = 'no-tests'
     deployConfig = [dev : 'always']


### PR DESCRIPTION
The `CoreUI@genesys.com` mailer doesn't seem to work as expected in Jenkins. I replaced the `CoreUI@genesys.com` mailer with my own email and tested using `useMailerOffMainline=true`. I verified that it did send an email to my email as expected. For now, I have just added all of our emails to the mailer until we can find out why the core ui mailing list isn't receiving emails sent from Jenkins. 

I also added the `chatGroupId` for the Core UI Chat room. If it works as expected, it should notify the chat room when there is a mainline build failure.