### PR TITLE
fix(popover): infinite loop in find-element-by-id

### DIFF
--- a/packages/genesys-spark-components/src/utils/dom/find-element-by-id.ts
+++ b/packages/genesys-spark-components/src/utils/dom/find-element-by-id.ts
@@ -2,11 +2,18 @@ export function findElementById(
   root: HTMLElement,
   forElementId: string
 ): HTMLElement {
+  let priorRoot = null;
   let rootNode = root.getRootNode();
   let forElement: HTMLElement;
 
-  while (rootNode && !forElement) {
-    forElement = (rootNode as Document)?.getElementById(forElementId);
+  while (rootNode && rootNode !== priorRoot && !forElement) {
+    const doc: Document =
+      rootNode.nodeType === Node.DOCUMENT_NODE
+        ? (rootNode as Document)
+        : rootNode.ownerDocument;
+    forElement = doc?.getElementById(forElementId);
+    // Keep track of the prior root to stop if a node returns itself as its root
+    priorRoot = rootNode;
     rootNode = rootNode.getRootNode();
   }
   return forElement;


### PR DESCRIPTION
Fixes an infinite loop in the `findElementById()` helper where in some cases a node returns itself from `getRootNode()`. Also in the same case where I observed getRootNode() return itself, rootNode was not a Document so the attempt to call `getElementById()` resulted in an uncaught error. This change also addresses that by checking the `nodeType` and using node.ownerDocument if the node itself is not a document.

https://inindca.atlassian.net/browse/COMUI-1757