### PR TITLE
fix(pagination): add fixed width to items per page dropdown

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-pagination-beta/gux-pagination-items-per-page-beta/gux-pagination-items-per-page-beta.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-pagination-beta/gux-pagination-items-per-page-beta/gux-pagination-items-per-page-beta.less
@@ -21,6 +21,11 @@ gux-pagination-items-per-page-beta {
 
     .gux-pagination-items-per-page-picker {
       margin-right: @gux-spacing-xs;
+
+      gux-dropdown {
+        display: inline-block;
+        width: 64px;
+      }
     }
 
     gux-dropdown {

--- a/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-items-per-page/gux-pagination-items-per-page.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-pagination/gux-pagination-items-per-page/gux-pagination-items-per-page.less
@@ -20,6 +20,11 @@ gux-pagination-items-per-page {
 
     .gux-pagination-items-per-page-picker {
       margin: 0 8px 0 16px;
+
+      gux-dropdown {
+        display: inline-block;
+        width: 64px;
+      }
     }
   }
 }


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-1742

Applied a fixed width to the items per page dropdown within both the `pagination-beta` and stable `pagination` components. The reasoning behind this was that in the issue above if you resize the pagination the dropdown will change sizes which will result in the truncation not being applied as the dropdown has increased by `7px`

The `width` I used was `64px` which is outlined in the figma design for pagination (https://genesysds.zeroheight.com/7978beca0/p/62953d-pagination/b/15a8df). There is no way to change the width of the dropdown so I chose to use the `part` selector to achieve this. I think it is probably reasonable to have this so end consumers can change the size of the dropdown ?