### PR TITLE
fix(gux-icon): prevent updates to svgHtml if baseSvgHtml is not set

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-icon/gux-icon.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/gux-icon.tsx
@@ -56,14 +56,18 @@ export class GuxIcon {
   watchDecorative(decorative: boolean): void {
     this.validateProps(decorative, this.screenreaderText);
 
-    this.svgHtml = this.getSvgWithAriaAttributes(this.baseSvgHtml);
+    if (this.baseSvgHtml) {
+      this.svgHtml = this.getSvgWithAriaAttributes(this.baseSvgHtml);
+    }
   }
 
   @Watch('screenreaderText')
   watchScreenreaderText(screenreaderText: string): void {
     this.validateProps(this.decorative, screenreaderText);
 
-    this.svgHtml = this.getSvgWithAriaAttributes(this.baseSvgHtml);
+    if (this.baseSvgHtml) {
+      this.svgHtml = this.getSvgWithAriaAttributes(this.baseSvgHtml);
+    }
   }
 
   async componentWillLoad(): Promise<void> {


### PR DESCRIPTION
In Firefox, updating the decorative or screenreader-text on a gux-icon that has never had an icon-name set (and triggered code resolved) reports an error to the console. This can be reproduced in the playground by adding a gux-icon without an icon-name set and programmatically altering either the decorative or screenreader-text value. 

My proposed approach is just to check that the baseSvgHtml has already been set before attempting to call the method that uses the baseSvgHtml to update the internal html of the component. If the icon-name is never set, the internals of the component are empty (existing behavior). If the icon-name is set, the same method that is bypassed by my changes will run after the baseSvgHtml is loaded asynchronously.