### PR TITLE
fix(popover): find-element-by-id tries to call getElementById non-document node

### DIFF
--- a/packages/genesys-spark-components/src/utils/dom/find-element-by-id.ts
+++ b/packages/genesys-spark-components/src/utils/dom/find-element-by-id.ts
@@ -1,3 +1,13 @@
+function getContainingDocument(node: Node): Document | DocumentFragment | null {
+  if (node.nodeType === Node.DOCUMENT_NODE) {
+    return node as Document;
+  }
+  if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+    return node as DocumentFragment;
+  }
+  return node.ownerDocument;
+}
+
 export function findElementById(
   root: HTMLElement,
   forElementId: string
@@ -7,10 +17,7 @@ export function findElementById(
   let forElement: HTMLElement;
 
   while (rootNode && rootNode !== priorRoot && !forElement) {
-    const doc: Document =
-      rootNode.nodeType === Node.DOCUMENT_NODE || Node.DOCUMENT_FRAGMENT_NODE
-        ? (rootNode as Document)
-        : rootNode.ownerDocument;
+    const doc = getContainingDocument(rootNode);
     forElement = doc?.getElementById(forElementId);
     // Keep track of the prior root to stop if a node returns itself as its root
     priorRoot = rootNode;


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-2135

Refactor the mechanism in find-element-by-id.ts for getting the Document/DocumentFragment instance to its own function that correctly handles the document fragment case. This addresses an issue introduced in the fix for COMUI-2000, which addressed an issue introduced in the fix for COMUI-1757!

https://inindca.atlassian.net/browse/COMUI-2000
https://inindca.atlassian.net/browse/COMUI-1757