### PR TITLE
COMUI-2107: gux-tooltip-text truncation

### DIFF
--- a/packages/genesys-spark-components/src/components/stable/gux-tooltip-title/gux-tooltip-title.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-tooltip-title/gux-tooltip-title.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { logWarn } from '../../../utils/error/log-error';
 import { OnMutation } from '../../../utils/decorator/on-mutation';
+import { afterNextRenderTimeout } from '@utils/dom/after-next-render';
 
 @Component({
   styleUrl: 'gux-tooltip-title.less',
@@ -71,7 +72,9 @@ export class GuxTooltipTitle {
   @OnMutation({ childList: true, subtree: true, characterData: true })
   onMutation(): void {
     this.titleName = this.setTooltipTitleText();
-    this.checkForTooltipHideOrShow();
+    afterNextRenderTimeout(() => {
+      this.checkForTooltipHideOrShow();
+    }, 500);
   }
 
   componentWillLoad() {


### PR DESCRIPTION
The gux-tooltip-text component was not properly truncating dynamic text within a gux-tab-panel. The reason for this was the gux-tab-panel on first render was hidden, so the two required properties, scrollWidth and offsetWidth, on the tooltip container was not a value above 0 until gux-tab-panel was finished processing some async events. I wrote code to wait for the next render until gux-tab-panel was done with all of its display processing before checking if the tooltip container was ready to be referenced.