### PR TITLE
fix(token): Renamed data-table scrollbar token

### DIFF
--- a/packages/genesys-spark-tokens/data/tokens.json
+++ b/packages/genesys-spark-tokens/data/tokens.json
@@ -6806,8 +6806,10 @@
         "type": "border"
       },
       "scrollbar": {
-        "value": "45px",
-        "type": "borderRadius",
+        "border_radius": {
+          "value": "45px",
+          "type": "borderRadius"
+        },
         "foreground_color": {
           "value": "{color.cornflower.600}",
           "type": "color"


### PR DESCRIPTION
Renamed the `data_table_items.scrollbar` token since it was causing issues with style-dictionary.