### PR TITLE
Calendar beta component

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/gux-calendar.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/gux-calendar.scss
@@ -1,0 +1,226 @@
+@import '../../../../../style/mixins';
+
+// Design tokens used for the calendar:
+//
+// @prop --gse-ui-calendarMenu-day-range-width ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-day-range-height ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-day-input-height
+// @prop --gse-ui-calendarMenu-day-input-width ** Not used. Where exactly should this be used?
+// @prop --gse-ui-calendarMenu-day-headerText-fontFamily
+// @prop --gse-ui-calendarMenu-day-headerText-lineHeight
+// @prop --gse-ui-calendarMenu-day-headerText-fontSize
+// @prop --gse-ui-calendarMenu-day-headerText-fontWeight
+// @prop --gse-ui-calendarMenu-day-date-size
+// @prop --gse-ui-calendarMenu-height ** Token not used. Where exactly should this be used?
+// @prop --gse-ui-calendarMenu-width ** Token not used. Where exactly should this be used?
+// @prop --gse-ui-calendarMenu-month-default-foregroundColor
+// @prop --gse-ui-calendarMenu-month-single-header-textWidth
+// @prop --gse-ui-calendarMenu-month-single-header-width ** Token not used. Is this needed?
+// @prop --gse-ui-calendarMenu-month-single-header-height ** Token not used. Is this needed?
+// @prop --gse-ui-calendarMenu-month-monthCell-width ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-month-monthCell-height ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-month-headerText-fontFamily
+// @prop --gse-ui-calendarMenu-month-headerText-lineHeight
+// @prop --gse-ui-calendarMenu-month-headerText-fontSize
+// @prop --gse-ui-calendarMenu-month-range-vertical-width ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-month-range-vertical-height ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-month-defaultText-fontFamily
+// @prop --gse-ui-calendarMenu-month-defaultText-lineHeight ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-month-defaultText-fontSize
+// @prop --gse-ui-calendarMenu-month-defaultText-fontWeight
+// @prop --gse-ui-calendarMenu-month-currentText-fontFamily
+// @prop --gse-ui-calendarMenu-month-currentText-lineHeight
+// @prop --gse-ui-calendarMenu-month-currentText-fontSize
+// @prop --gse-ui-calendarMenu-month-currentText-fontWeight
+// @prop --gse-ui-calendarMenu-month-borderRadius
+// @prop --gse-ui-calendarMenu-month-focusBorderRadius
+// @prop --gse-ui-calendarMenu-month-selected-foregroundColor
+// @prop --gse-ui-calendarMenu-month-selected-backgroundColor
+// @prop --gse-ui-calendarMenu-month-selected-hoverBackgroundColor
+// @prop --gse-ui-calendarMenu-month-hover-backgroundColor
+// @prop --gse-ui-calendarMenu-dateBody-padding
+// @prop --gse-ui-calendarMenu-dateBody-gap ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-header-backgroundColor
+// @prop --gse-ui-calendarMenu-header-foregroundColor
+// @prop --gse-ui-calendarMenu-header-gap ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-header-padding
+// @prop --gse-ui-calendarMenu-backgroundColor
+// @prop --gse-ui-calendarMenu-date-defaultText-fontFamily
+// @prop --gse-ui-calendarMenu-date-defaultText-lineHeight ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-date-defaultText-fontSize
+// @prop --gse-ui-calendarMenu-date-defaultText-fontWeight
+// @prop --gse-ui-calendarMenu-date-currentText-fontFamily
+// @prop --gse-ui-calendarMenu-date-currentText-lineHeight ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-date-currentText-fontSize
+// @prop --gse-ui-calendarMenu-date-currentText-fontWeight
+// @prop --gse-ui-calendarMenu-date-selected-foregroundColor
+// @prop --gse-ui-calendarMenu-date-selected-backgroundColor
+// @prop --gse-ui-calendarMenu-date-selected-hoverBackgroundColor
+// @prop --gse-ui-calendarMenu-date-hover-backgroundColor
+// @prop --gse-ui-calendarMenu-date-range-backgroundColor ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-date-default-foregroundColor
+// @prop --gse-ui-calendarMenu-single-header-borderRadius
+// @prop --gse-ui-calendarMenu-single-body-borderRadius
+// @prop --gse-ui-calendarMenu-range-header-firstMonth-borderRadius ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-range-header-secondMonth-borderRadius ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-range-body-firstMonth-borderRadius ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-range-body-secondMonth-borderRadius ** Token not used. Range logic will be implemented in the future
+// @prop --gse-ui-calendarMenu-disabled-opacity
+// @prop --gse-ui-calendarMenu-monthBody-padding
+// @prop --gse-ui-calendarMenu-monthBody-gap ** Token not used. Do we need this?
+// @prop --gse-ui-calendarMenu-boxShadow-color ** Token not used. Can we combine all box-shadow tokens into one token?
+// @prop --gse-ui-calendarMenu-boxShadow-type ** Token not used. Can we combine all box-shadow tokens into one token?
+// @prop --gse-ui-calendarMenu-boxShadow-x ** Token not used. Can we combine all box-shadow tokens into one token?
+// @prop --gse-ui-calendarMenu-boxShadow-y ** Token not used. Can we combine all box-shadow tokens into one token?
+// @prop --gse-ui-calendarMenu-boxShadow-blur ** Token not used. Can we combine all box-shadow tokens into one token?
+// @prop --gse-ui-calendarMenu-boxShadow-spread ** Token not used. Can we combine all box-shadow tokens into one token?
+
+.gux-calendar-beta {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: column;
+  background: var(--gse-ui-calendarMenu-date-selected-foregroundColor);
+  // TODO: Get box-shadow token working instead of hardcoding
+  // box-shadow: var(--gse-ui-calendarMenu-boxShadow-color)px var(--gse-ui-calendarMenu-boxShadow-x)px var(--gse-ui-calendarMenu-boxShadow-y)px var(--gse-ui-calendarMenu-boxShadow-blur)px var(----gse-ui-calendarMenu-boxShadow-spread)px;
+  box-shadow: rgba(34, 37, 41, 0.24) 0px 2px 4px;
+  border-radius: var(--gse-ui-calendarMenu-single-body-borderRadius);
+  font-size: var(--gse-ui-calendarMenu-month-defaultText-fontSize);
+  font-family: var(--gse-ui-calendarMenu-month-defaultText-fontFamily);
+
+  .gux-header {
+    display: flex;
+    align-items: center;
+    padding: var(--gse-ui-calendarMenu-header-padding);
+    font-style: normal;
+    font-weight: var(--gse-ui-calendarMenu-month-currentText-fontWeight);
+    color: var(--gse-ui-calendarMenu-header-foregroundColor);
+    text-align: center;
+    background-color: var(--gse-ui-calendarMenu-header-backgroundColor);
+    border-radius: var(--gse-ui-calendarMenu-single-header-borderRadius);
+    justify-content: space-between;
+    height: var(--gse-ui-calendarMenu-month-single-header-height);
+
+    .gux-header-month-and-year {
+      width: var(--gse-ui-calendarMenu-month-single-header-textWidth);
+      color: var(--gse-ui-calendarMenu-month-selected-foregroundColor);
+      font-family: var(--gse-ui-calendarMenu-month-headerText-fontFamily);
+      line-height: var(--gse-ui-calendarMenu-month-headerText-lineHeight);
+      font-size: var(--gse-ui-calendarMenu-month-headerText-fontSize);
+    }
+
+    .gux-left,
+    .gux-right {
+      color: var(--gse-ui-calendarMenu-month-monthHeader-foregroundColor);
+      cursor: pointer;
+      background: none;
+      border: none;
+      outline: none;
+
+      &:focus-visible {
+        outline: 2px solid #aac9ff;
+        outline-offset: 1px;
+      }
+
+      gux-icon {
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+
+  .gux-week-days {
+    padding-top: 24px;
+    padding-right: 24px;
+    padding-left: 24px;
+    text-align: center;
+    color: var(--gse-ui-calendarMenu-day-dayHeader-foregroundColor);
+    font-family: var(--gse-ui-calendarMenu-day-headerText-fontFamily);
+    font-size: var(--gse-ui-calendarMenu-day-headerText-fontSize);
+    font-family: var(--gse-ui-calendarMenu-day-headerText-fontFamily);
+    font-weight: var(--gse-ui-calendarMenu-day-headerText-fontWeight);
+
+    .gux-week-day {
+      display: inline-block;
+      width: var(--gse-ui-calendarMenu-day-date-size);
+      height: 16px;
+      font-weight: var(--gse-ui-calendarMenu-day-header-fontWeight);
+    }
+  }
+
+  .gux-content {
+    padding: var(--gse-ui-calendarMenu-dateBody-padding);
+    color: var(--gse-core-color-cornflower-900);
+    background-color: var(--gse-ui-calendarMenu-backgroundColor);
+    border-radius: var(--gse-ui-calendarMenu-single-body-borderRadius);
+  }
+
+  .gux-content-week {
+    .gux-content-date {
+      display: inline-block;
+      width: var(--gse-ui-calendarMenu-day-date-size);
+      height: var(--gse-ui-calendarMenu-day-input-height);
+      font-style: normal;
+      font-weight: var(--gse-ui-calendarMenu-date-defaultText-fontWeight);
+      line-height: 32px;
+      text-align: center;
+      vertical-align: middle;
+      border: none;
+      outline: none;
+      color: var(--gse-core-color-cornflower-600);
+      font-size: var(--gse-ui-calendarMenu-date-defaultText-fontSize);
+      font-family: var(--gse-ui-calendarMenu-date-currentText-fontFamily);
+      opacity: var(--gse-ui-calendarMenu-disabled-opacity);
+
+      &.gux-current-month {
+        // TODO: Is this the correct token to use here?
+        color: var(--gse-ui-calendarMenu-month-default-foregroundColor);
+        opacity: 1;
+      }
+
+      &.gux-hidden {
+        display: none;
+      }
+
+      &.gux-disabled {
+        pointer-events: none;
+      }
+
+      &.gux-selected {
+        color: var(--gse-ui-calendarMenu-date-selected-foregroundColor);
+        background-color: var(
+          --gse-ui-calendarMenu-date-selected-backgroundColor
+        );
+        border: none;
+        border-radius: var(--gse-ui-calendarMenu-month-borderRadius);
+        outline: none;
+
+        &:hover {
+          background-color: var(
+            --gse-ui-calendarMenu-date-selected-hoverBackgroundColor
+          );
+        }
+      }
+
+      &:hover {
+        cursor: pointer;
+        background-color: var(--gse-ui-calendarMenu-date-hover-backgroundColor);
+        border-radius: var(--gse-ui-calendarMenu-month-borderRadius);
+      }
+
+      &:focus-visible {
+        outline: 1px solid #7b61ff;
+        border-radius: var(--gse-ui-calendarMenu-month-focusBorderRadius);
+      }
+
+      .gux-sr-only {
+        @include gux-sr-only-clip;
+      }
+
+      &.gux-current-date {
+        font-weight: var(--gse-ui-calendarMenu-date-currentText-fontWeight);
+        font-family: var(--gse-ui-calendarMenu-month-currentText-fontFamily);
+        font-size: var(--gse-ui-calendarMenu-date-currentText-fontSize);
+      }
+    }
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/gux-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/gux-calendar.tsx
@@ -1,0 +1,351 @@
+import { Component, Element, h, JSX, State } from '@stencil/core';
+import { IWeekElement, GuxCalendarDayOfWeek } from '../../gux-calendar.types';
+import { fromIsoDate } from '@utils/date/iso-dates';
+import {
+  getWeekdays,
+  getFirstOfMonth,
+  getDateAsMonthYear,
+  firstDateInMonth
+} from '../../services/calendar.service';
+import { getDesiredLocale, getStartOfWeek } from '../../../../../i18n';
+import { buildI18nForComponent, GetI18nValue } from '../../../../../i18n';
+import translationResources from '../../i18n/en.json';
+import { afterNextRenderTimeout } from '@utils/dom/after-next-render';
+import { logError } from '@utils/error/log-error';
+import simulateNativeEvent from '../../../../../utils/dom/simulate-native-event';
+
+@Component({
+  styleUrl: 'gux-calendar.scss',
+  tag: 'gux-calendar-beta',
+  shadow: true
+})
+export class GuxCalendar {
+  @Element()
+  root: HTMLElement;
+
+  @State()
+  private focusedValue: Date;
+
+  @State()
+  private minValue: Date;
+
+  @State()
+  private maxValue: Date;
+
+  private locale: string = 'en';
+
+  private i18n: GetI18nValue;
+
+  // Total number of dates that will display for each month in the calendar
+  private MONTH_DATE_COUNT: number = 42;
+
+  // Keeps track of the start day of the week based on user's locale
+  // Some locales will have the start day of the week be different than others
+  private startDayOfWeek: GuxCalendarDayOfWeek;
+
+  private get slottedInput(): HTMLInputElement {
+    return this.root.querySelector('input[type="date"]');
+  }
+
+  async componentWillLoad(): Promise<void> {
+    if (!this.slottedInput) {
+      logError(
+        this.root,
+        'You must slot a date input element like so: input[type="date"].'
+      );
+    }
+
+    this.locale = getDesiredLocale(this.root);
+
+    // Set start day of week
+    const startDayOfWeek = this.slottedInput.getAttribute('start-day-of-week');
+    if (startDayOfWeek?.length) {
+      this.startDayOfWeek = parseInt(
+        startDayOfWeek,
+        10
+      ) as GuxCalendarDayOfWeek;
+    }
+    this.startDayOfWeek = this.startDayOfWeek || getStartOfWeek(this.locale);
+
+    this.i18n = await buildI18nForComponent(this.root, translationResources);
+
+    if (this.slottedInput.value) {
+      this.focusedValue = fromIsoDate(this.slottedInput.value);
+    }
+
+    // Set min value from the "min" input prop
+    if (this.slottedInput.min) {
+      this.minValue = new Date(this.slottedInput.min);
+      this.minValue.setHours(0, 0, 0, 0);
+    }
+    // Set max value from the "max" input prop
+    if (this.slottedInput.max) {
+      this.maxValue = new Date(this.slottedInput.max);
+      this.maxValue.setHours(0, 0, 0, 0);
+    }
+  }
+
+  private onDateClick(date: Date): void {
+    this.focusedValue = new Date(date.getTime());
+    this.slottedInput.value = date.toISOString().substring(0, 10);
+    simulateNativeEvent(this.root, 'input');
+  }
+
+  private setDateAfterArrowKeyPress(
+    event: KeyboardEvent,
+    newDayValue: number
+  ): void {
+    event.preventDefault();
+    this.focusedValue = new Date(
+      this.getFocusedValue().getFullYear(),
+      this.getFocusedValue().getMonth(),
+      this.getFocusedValue().getDate() + newDayValue,
+      0,
+      0,
+      0
+    );
+    afterNextRenderTimeout(() => {
+      this.focusDate();
+    });
+  }
+
+  /**
+   * Focus the focused date
+   */
+  private focusDate() {
+    const target: HTMLTableCellElement = this.root.shadowRoot.querySelector(
+      `.gux-content-date[data-date="${this.focusedValue.getTime()}"]`
+    );
+    if (target) {
+      target.focus();
+    }
+  }
+
+  private onKeyDown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case ' ':
+        break;
+      case 'Enter':
+        event.preventDefault();
+        this.onDateClick(this.getFocusedValue());
+        afterNextRenderTimeout(() => {
+          this.focusDate();
+        });
+        break;
+      case 'ArrowDown':
+        this.setDateAfterArrowKeyPress(event, 7);
+        break;
+      case 'ArrowUp':
+        this.setDateAfterArrowKeyPress(event, -7);
+        break;
+      case 'ArrowLeft':
+        this.setDateAfterArrowKeyPress(event, -1);
+        break;
+      case 'ArrowRight':
+        this.setDateAfterArrowKeyPress(event, 1);
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        this.setNewFocusedMonth(1);
+        afterNextRenderTimeout(() => {
+          this.focusDate();
+        });
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        this.setNewFocusedMonth(-1);
+        afterNextRenderTimeout(() => {
+          this.focusDate();
+        });
+        break;
+    }
+  }
+
+  private getMonthDays(): IWeekElement[] {
+    const firstOfMonth = getFirstOfMonth(this.getFocusedValue());
+    const weeks = [];
+    let currentWeek = { dates: [] };
+    let weekDayIndex = 0;
+    const currentMonth = firstOfMonth.getMonth();
+    const selectedValue = this.getSelectedValue();
+    const firstOfMonthDate = new Date(firstOfMonth.getTime());
+    const currentDate = firstDateInMonth(
+      currentMonth,
+      firstOfMonthDate.getFullYear(),
+      this.startDayOfWeek
+    );
+
+    // Generate all of the dates in the current month
+    for (let d = 0; d < this.MONTH_DATE_COUNT + 1; d += 1) {
+      const selected =
+        selectedValue.getTime() === currentDate.getTime() &&
+        this.focusedValue !== undefined;
+
+      if (weekDayIndex > 0 && weekDayIndex % 7 === 0) {
+        weeks.push(currentWeek);
+        currentWeek = {
+          dates: []
+        };
+      }
+
+      // Disable a date that is outside the defined date range boundaries
+      const disabled =
+        (this.minValue && currentDate.getTime() <= this.minValue.getTime()) ||
+        (this.maxValue && currentDate.getTime() > this.maxValue.getTime());
+
+      const focused =
+        this.getFocusedValue()?.getTime() === currentDate.getTime() &&
+        this.getFocusedValue()?.getTime() !== selectedValue.getTime(); // Do not show preview value for date if it's already selected
+
+      const today = new Date();
+
+      currentWeek.dates.push({
+        date: new Date(currentDate),
+        disabled,
+        inCurrentMonth: currentMonth === currentDate.getMonth() && !disabled,
+        selected: selected && selectedValue,
+        focused,
+        isCurrentDate:
+          currentDate.getDate() === today.getDate() &&
+          currentDate.getMonth() === today.getMonth() &&
+          currentDate.getFullYear() === today.getFullYear()
+      });
+      weekDayIndex += 1;
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return weeks as IWeekElement[];
+  }
+
+  private getFocusedValue(): Date {
+    if (this.focusedValue) {
+      return this.focusedValue;
+    }
+    return this.getSelectedValue();
+  }
+
+  private changeMonth(newMonthValue: number): Date {
+    return new Date(
+      this.getFocusedValue().getFullYear(),
+      this.getFocusedValue().getMonth() + newMonthValue,
+      1,
+      0,
+      0,
+      0
+    );
+  }
+
+  private setNewFocusedMonth(newMonthValue: number): void {
+    this.focusedValue = this.changeMonth(newMonthValue);
+  }
+
+  private getSelectedValue(): Date {
+    if (this.slottedInput.value) {
+      const value = fromIsoDate(this.slottedInput.value);
+      return value;
+    }
+
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    return now;
+  }
+
+  private renderHeader(): JSX.Element {
+    return (
+      <div class="gux-header">
+        <button
+          type="button"
+          class="gux-left"
+          aria-label={this.i18n('previousMonth', {
+            localizedPreviousMonthAndYear: getDateAsMonthYear(
+              this.changeMonth(-1),
+              this.locale
+            )
+          })}
+          onClick={() => this.setNewFocusedMonth(-1)}
+        >
+          <gux-icon decorative icon-name="chevron-small-left"></gux-icon>
+        </button>
+        <span class="gux-header-month-and-year">
+          {getDateAsMonthYear(this.getFocusedValue(), this.locale)}
+        </span>
+        <button
+          type="button"
+          class="gux-right"
+          aria-label={this.i18n('nextMonth', {
+            localizedNextMonthAndYear: getDateAsMonthYear(
+              this.changeMonth(1),
+              this.locale
+            )
+          })}
+          onClick={() => this.setNewFocusedMonth(1)}
+        >
+          <gux-icon decorative icon-name="chevron-small-right"></gux-icon>
+        </button>
+      </div>
+    ) as JSX.Element;
+  }
+
+  private renderContent(): JSX.Element {
+    return (
+      <div>
+        <div class="gux-week-days">
+          {getWeekdays(this.locale, this.startDayOfWeek).map(
+            day => (<div class="gux-week-day">{day}</div>) as JSX.Element
+          )}
+        </div>
+
+        <div class="gux-content">
+          {this.getMonthDays().map(
+            week =>
+              (
+                <div class="gux-content-week">
+                  {week.dates.map(
+                    day =>
+                      (
+                        <div
+                          data-date={day.date.getTime()}
+                          onClick={() => this.onDateClick(day.date)}
+                          role="button"
+                          aria-current={day.selected ? 'true' : 'false'}
+                          tabindex={day.selected || day.focused ? '0' : '-1'}
+                          onKeyDown={e => void this.onKeyDown(e)}
+                          aria-disabled={day.disabled ? 'true' : 'false'}
+                          class={{
+                            'gux-content-date': true,
+                            'gux-disabled': day.disabled,
+                            'gux-current-month': day.inCurrentMonth,
+                            'gux-selected': day.selected,
+                            'gux-current-date': day.isCurrentDate
+                          }}
+                        >
+                          <span class="gux-non-sr" aria-hidden="true">
+                            {day.date.getDate()}
+                          </span>
+                          <span class="gux-sr-only">
+                            <gux-date-beta
+                              datetime={day.date.toISOString()}
+                              format="long"
+                            ></gux-date-beta>
+                          </span>
+                        </div>
+                      ) as JSX.Element
+                  )}
+                </div>
+              ) as JSX.Element
+          )}
+        </div>
+      </div>
+    ) as JSX.Element;
+  }
+
+  render(): JSX.Element {
+    return (
+      <div class="gux-calendar-beta">
+        <slot />
+        {this.renderHeader()}
+        {this.renderContent()}
+      </div>
+    ) as JSX.Element;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/components/single/readme.md
@@ -1,0 +1,25 @@
+# gux-calendar-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Depends on
+
+- [gux-icon](../../../../stable/gux-icon)
+- [gux-date-beta](../../../gux-date)
+
+### Graph
+```mermaid
+graph TD;
+  gux-calendar-beta --> gux-icon
+  gux-calendar-beta --> gux-date-beta
+  style gux-calendar-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/example.html
@@ -1,0 +1,91 @@
+<h1>gux-calendar</h1>
+
+<h2>Single Date Selection</h2>
+<gux-calendar-beta oninput="notify(event)">
+  <input type="date" value="2023-05-19" />
+</gux-calendar-beta>
+
+<h2>Empty Date Selection</h2>
+<gux-calendar-beta oninput="notify(event)">
+  <input type="date" />
+</gux-calendar-beta>
+
+<h2>Single Date Selection with min and max set</h2>
+<gux-calendar-beta oninput="notify(event)">
+  <input type="date" value="2023-05-19" min="2023-04-28" max="2023-06-18" />
+</gux-calendar-beta>
+
+<h2>Start day of week</h2>
+<div class="container">
+  <div class="item">
+    <h3>Monday</h3>
+    <gux-calendar-beta oninput="notify(event)">
+      <input type="date" value="2023-07-28" start-day-of-week="1" />
+    </gux-calendar-beta>
+  </div>
+  <div class="item">
+    <h3>Saturday</h3>
+    <gux-calendar-beta oninput="notify(event)">
+      <input type="date" value="2023-07-28" start-day-of-week="6" />
+    </gux-calendar-beta>
+  </div>
+  <div class="item">
+    <h3>Sunday</h3>
+    <gux-calendar-beta oninput="notify(event)">
+      <input type="date" value="2023-07-28" start-day-of-week="7" />
+    </gux-calendar-beta>
+  </div>
+</div>
+
+<h2>Languages</h2>
+<div id="languages-container">
+  <div id="sample"></div>
+</div>
+
+<style
+  onload="(function () {
+  const languagesContainer = document.getElementById('languages-container');
+  [
+    'ar', 'cs', 'da', 'de', 'en', 'es-es', 'es', 'fi','fr-ca',
+    'fr', 'he','it', 'ja', 'ko', 'nl', 'no', 'pl', 'pt-br',
+    'pt-pt', 'ru', 'sv', 'th', 'tr', 'uk', 'zh-cn', 'zh-tw'
+  ].forEach((lang) => {
+    const today = new Date().toLocaleDateString('fr-CA', { year: 'numeric', month: '2-digit', day: '2-digit' });
+    const html = window.toHTML([
+      '<div class=language lang=' + lang + '>',
+        '<h3>' + lang + '</h3>',
+        '<gux-calendar-beta>',
+        '<input type=date oninput=' + notify(event) + ' value=' + today + ' />',
+        '</gux-calendar-beta>',
+      '</div>'
+    ].join(''));
+    languagesContainer.appendChild(html);
+  });
+})()"
+>
+  #languages-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .language {
+    padding: 10px 25px;
+  }
+</style>
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-content: stretch;
+    justify-content: flex-start;
+  }
+
+  .item {
+    flex: 0 1 auto;
+    align-self: auto;
+  }
+</style>

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/gux-calendar.light.scss
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/gux-calendar.light.scss
@@ -1,0 +1,6 @@
+gux-calendar-beta {
+  input[type='date'] {
+    display: none;
+    -webkit-appearance: none;
+  }
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/gux-calendar.types.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/gux-calendar.types.ts
@@ -1,0 +1,15 @@
+export interface IWeekElement {
+  dates: IDateElement[];
+}
+
+export interface IDateElement {
+  date: Date;
+  disabled: boolean;
+  selected: boolean;
+  inCurrentMonth: boolean;
+  tabIndex: string;
+  isCurrentDate: boolean;
+  focused: boolean;
+}
+
+export type GuxCalendarDayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/i18n/en.json
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "previousMonth": "Previous month: {localizedPreviousMonthAndYear}",
+  "nextMonth": "Next month: {localizedNextMonthAndYear}"
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/readme.md
@@ -1,0 +1,23 @@
+# gux-calendar-beta
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Dependencies
+
+### Depends on
+
+- [gux-icon](../../stable/gux-icon)
+
+### Graph
+```mermaid
+graph TD;
+  gux-calendar-beta --> gux-icon
+  style gux-calendar-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/services/calendar.service.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/services/calendar.service.ts
@@ -1,0 +1,45 @@
+import { capitalizeFirstLetter } from '@utils/string/capitalize-first-letter';
+
+export function getFirstOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1, 0, 0, 0);
+}
+
+export function getWeekdays(
+  locale: Intl.LocalesArgument,
+  startDayOfWeek: number
+): string[] {
+  const days: string[] = [];
+  // Sunday
+  const day = new Date(1970, 0, 4);
+
+  for (let i = 0; i < 7; i++) {
+    const weekday = day.toLocaleString(locale, { weekday: 'narrow' });
+    days.push(weekday);
+    day.setDate(day.getDate() + 1);
+  }
+
+  return rotateArray(days, startDayOfWeek);
+}
+
+export function getDateAsMonthYear(date: Date, locale: string) {
+  return capitalizeFirstLetter(
+    date.toLocaleDateString(locale, { year: 'numeric', month: 'long' })
+  );
+}
+
+function rotateArray(arr: string[], n: number): string[] {
+  const times = n % arr.length;
+  return arr.concat(arr.splice(0, times));
+}
+
+export function firstDateInMonth(
+  month: number,
+  year: number,
+  startDayOfWeek: number
+) {
+  const startDate = new Date(year, month, 1, 0, 0, 0, 0);
+  const firstDayOfMonth = startDate.getDay();
+  const firstDayOffset = (-1 * (startDayOfWeek - firstDayOfMonth - 7)) % 7;
+
+  return new Date(startDate.getTime() - firstDayOffset * (86400 * 1000));
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/services/tests.service.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/services/tests.service.ts
@@ -1,0 +1,53 @@
+import { E2EElement, E2EPage } from '@stencil/core/testing';
+
+export async function validateSelectedDate(
+  element: E2EElement,
+  expectedMonthAndYear: string,
+  expectedDay: string
+) {
+  const selectedDate = await element.find('pierce/.gux-selected .gux-non-sr');
+  const currentMonthAndYear = await element.find(
+    'pierce/.gux-header-month-and-year'
+  );
+  expect(currentMonthAndYear.innerHTML).toBe(expectedMonthAndYear);
+  expect(selectedDate.innerHTML).toBe(expectedDay);
+}
+
+export async function validateHeaderMonth(
+  element: E2EElement,
+  expectedMonthAndYear: string
+) {
+  const currentMonthAndYear = await element.find(
+    'pierce/.gux-header-month-and-year'
+  );
+  expect(currentMonthAndYear.innerHTML).toBe(expectedMonthAndYear);
+}
+
+export async function getContentDateElement(
+  element: E2EElement,
+  dateAsMonthDayYear: string
+): Promise<E2EElement> {
+  return await element.find(
+    `pierce/.gux-content-date[data-date="${new Date(
+      dateAsMonthDayYear
+    ).getTime()}"]`
+  );
+}
+
+export async function goToPreviousMonth(
+  element: E2EElement,
+  page: E2EPage
+): Promise<void> {
+  const button = await element.find('pierce/.gux-left');
+  await button.click();
+  return await page.waitForChanges();
+}
+
+export async function goToNextMonth(
+  element: E2EElement,
+  page: E2EPage
+): Promise<void> {
+  const button = await element.find('pierce/.gux-right');
+  await button.click();
+  return await page.waitForChanges();
+}

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/tests/gux-calendar.e2e.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/tests/gux-calendar.e2e.ts
@@ -1,0 +1,270 @@
+import { newSparkE2EPage } from '../../../../test/e2eTestUtils';
+import {
+  goToPreviousMonth,
+  goToNextMonth,
+  validateHeaderMonth,
+  validateSelectedDate,
+  getContentDateElement
+} from '../services/tests.service';
+
+describe('gux-calendar', () => {
+  const defaultHtml = `
+    <gux-calendar-beta>
+      <input type="date" value="2023-05-19" min="2023-04-28" max="2023-06-18" />
+    </gux-calendar-beta>
+    `;
+
+  it('renders', async () => {
+    const page = await newSparkE2EPage({
+      html: defaultHtml
+    });
+    const element = await page.find('gux-calendar-beta');
+    expect(element).toHaveAttribute('hydrated');
+  });
+
+  describe('header', () => {
+    it('calendar increments by one month after clicking the right arrow button', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      // Validate that the current month before clicking the right arrow is May, 2023
+      await validateHeaderMonth(element, 'May 2023');
+
+      await goToNextMonth(element, page);
+      // await a11yCheck(page);
+
+      // Validate that the new month after clicking the right arrow is June, 2023
+      await validateHeaderMonth(element, 'June 2023');
+    });
+
+    it('calendar decrements by one month after clicking the left arrow button', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      // Validate that the current month before clicking the left arrow is May, 2023
+      await validateHeaderMonth(element, 'May 2023');
+
+      await goToPreviousMonth(element, page);
+
+      // Validate that the new month after clicking the left arrow  is April, 2023
+      await validateHeaderMonth(element, 'April 2023');
+    });
+  });
+
+  describe('content', () => {
+    it('selected date on page load is correct', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      // Validate that the selected date on page load is May 19, 2023
+      await validateSelectedDate(element, 'May 2023', '19');
+    });
+
+    it('clicking on a date in the current month causes the date to be selected', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+
+      // Find May 10, 2023 in the calendar and click it so that it will be selected
+      const element = await page.find('gux-calendar-beta');
+      const contentDate = await getContentDateElement(element, 'May 10, 2023');
+      await contentDate.click();
+      await page.waitForChanges();
+
+      // Validate that clicking on May 10, 2023 causes it to be selected
+      await validateSelectedDate(element, 'May 2023', '10');
+    });
+
+    it('clicking on a date in the next month causes the date to be selected', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+
+      // Find June 1, 2023 in the calendar and click it so that it will be selected
+      const element = await page.find('gux-calendar-beta');
+      const contentDate = await getContentDateElement(element, 'June 1, 2023');
+      await contentDate.click();
+      await page.waitForChanges();
+
+      // Validate that clicking on June 1, 2023 causes it to be selected
+      await validateSelectedDate(element, 'June 2023', '1');
+    });
+
+    it('clicking on a date in the previous month causes the date to be selected', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+
+      // Find April 30, 2023 in the calendar and click it so that it will be selected
+      const element = await page.find('gux-calendar-beta');
+      const contentDate = await getContentDateElement(
+        element,
+        'April 30, 2023'
+      );
+      await contentDate.click();
+      await page.waitForChanges();
+
+      // Validate that clicking on April 30, 2023 causes it to be selected
+      await validateSelectedDate(element, 'April 2023', '30');
+    });
+
+    describe('arrow key and page up/down navigation', () => {
+      it('pressing the down arrow key and then the enter key cause the selected date to increment by 1 week', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the down arrow key and then the enter key
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateSelectedDate(element, 'May 2023', '26');
+      });
+
+      it('pressing the up arrow key and then the enter key cause the selected date to decrement by 1 week', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the up arrow key and then the enter key
+        await page.keyboard.press('ArrowUp');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateSelectedDate(element, 'May 2023', '12');
+      });
+
+      it('pressing the right arrow key and then the enter key cause the selected date to increment by 1 day', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the right arrow key and then the enter key
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateSelectedDate(element, 'May 2023', '20');
+      });
+
+      it('pressing the left arrow key and then the enter key cause the selected date to decrement by 1 day', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the left arrow key and then the enter key
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateSelectedDate(element, 'May 2023', '18');
+      });
+
+      it('pressing the page down key causes the current month to decrement by 1 month', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the left arrow key and then the enter key
+        await page.keyboard.press('PageDown');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateHeaderMonth(element, 'April 2023');
+      });
+
+      it('pressing the page up key causes the current month to increment by 1 month', async () => {
+        const page = await newSparkE2EPage({
+          html: defaultHtml
+        });
+        const element = await page.find('gux-calendar-beta');
+
+        // First click the selected date to get focus on the calendar
+        const selectedDate = await element.find('pierce/.gux-selected');
+        await selectedDate.click();
+
+        // Press the left arrow key and then the enter key
+        await page.keyboard.press('PageUp');
+        await page.keyboard.press('Enter');
+        await page.waitForChanges();
+
+        await validateHeaderMonth(element, 'June 2023');
+      });
+    });
+
+    it('setting max prop causes an upper bound range to be implemented correctly', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      // Go to next month
+      await goToNextMonth(element, page);
+
+      const contentDate = await getContentDateElement(element, 'June 19, 2023');
+      expect(contentDate.className).toContain('gux-disabled');
+    });
+
+    it('setting min prop causes a lower bound range to be implemented correctly', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      await goToPreviousMonth(element, page);
+
+      const contentDate = await getContentDateElement(
+        element,
+        'April 27, 2023'
+      );
+      expect(contentDate.className).toContain('gux-disabled');
+    });
+
+    it('tab index is set to 0 for selected date and -1 for non-selected date', async () => {
+      const page = await newSparkE2EPage({
+        html: defaultHtml
+      });
+      const element = await page.find('gux-calendar-beta');
+
+      const selectedDate = await getContentDateElement(element, 'May 19, 2023');
+      const nonSelectedDate = await getContentDateElement(
+        element,
+        'May 20, 2023'
+      );
+      expect(selectedDate.tabIndex).toBe(0);
+      expect(nonSelectedDate.tabIndex).toBe(-1);
+    });
+  });
+});

--- a/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/tests/gux-calendar.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-calendar-beta/tests/gux-calendar.spec.ts
@@ -1,0 +1,24 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { GuxCalendar } from '../components/single/gux-calendar';
+
+const components = [GuxCalendar];
+const language = 'en';
+const html = `
+<gux-calendar-beta>
+  <input type="date" value="2023-05-19" min="2023-04-28" max="2023-06-18" />
+</gux-calendar-beta>
+`;
+
+describe('gux-calendar', () => {
+  it('should build', async () => {
+    const page = await newSpecPage({ components, html, language });
+
+    expect(page.rootInstance).toBeInstanceOf(GuxCalendar);
+  });
+
+  it('renders', async () => {
+    const page = await newSpecPage({ components, html, language });
+
+    expect(page.root).toMatchSnapshot();
+  });
+});

--- a/packages/genesys-spark-components/src/components/beta/gux-date/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-date/readme.md
@@ -13,6 +13,19 @@
 | `format`   | `format`   | Format option type                                  | `"full" \| "long" \| "medium" \| "short"` | `'short'`                  |
 
 
+## Dependencies
+
+### Used by
+
+ - [gux-calendar-beta](../gux-calendar-beta/components/single)
+
+### Graph
+```mermaid
+graph TD;
+  gux-calendar-beta --> gux-date-beta
+  style gux-date-beta fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/genesys-spark-components/src/components/stable/gux-icon/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-icon/readme.md
@@ -23,6 +23,7 @@
  - [gux-advanced-dropdown](../gux-advanced-dropdown)
  - [gux-button-multi](../gux-button-multi)
  - [gux-calendar](../gux-calendar)
+ - [gux-calendar-beta](../../beta/gux-calendar-beta/components/single)
  - [gux-column-manager-item](../../beta/gux-column-manager/gux-column-manager-item)
  - [gux-content-search](../gux-content-search)
  - [gux-context-menu-beta](../../beta/gux-context-menu)
@@ -81,6 +82,7 @@ graph TD;
   gux-advanced-dropdown --> gux-icon
   gux-button-multi --> gux-icon
   gux-calendar --> gux-icon
+  gux-calendar-beta --> gux-icon
   gux-column-manager-item --> gux-icon
   gux-content-search --> gux-icon
   gux-context-menu-beta --> gux-icon

--- a/packages/genesys-spark-components/src/i18n/translations/en.json
+++ b/packages/genesys-spark-components/src/i18n/translations/en.json
@@ -10,6 +10,10 @@
     "red-bold": "badge with label: {label}, color: red bold",
     "inherit": "badge with label: {label}"
   },
+  "gux-calendar-beta": {
+    "previousMonth": "Previous month: {localizedPreviousMonthAndYear}",
+    "nextMonth": "Next month: {localizedNextMonthAndYear}"
+  },
   "gux-column-manager-item": {
     "activateReordering": "Activate reordering mode for {columnName} column"
   },

--- a/packages/genesys-spark-components/src/style/style.less
+++ b/packages/genesys-spark-components/src/style/style.less
@@ -16,6 +16,7 @@
 @import url('../components/stable/gux-form-field/gux-form-field.light.less');
 @import url('../components/beta/gux-table/gux-table.light.less');
 @import url('../components/stable/gux-button-multi/gux-button-multi.light.less');
+@import url('../components/beta/gux-calendar-beta/gux-calendar.light.scss');
 
 gux-action-toast-legacy {
   dl {


### PR DESCRIPTION
Added a gux-calendar-beta component.

Figma file linked to the JIRA ticket for this PR: https://www.figma.com/file/JKbHmcf4nUF6C7Pj8M6MpY/Spark%3A-Ember-2.0---Core?type=design&node-id=548-28980&mode=design&t=MN4Mz9Uple6OzKWs-0

The current plan is to build a gux-calendar-beta component that will be built from scratch with a fresh perspective. We decided to slot in a date input field but then hide this slotted date input in the UI and instead show custom calendar styling and logic the per gux-calendar-beta component. This is the date/calendar component setup we have decided on going forward.

gux-calendar-beta -> handles single date selection logic
gux-calendar-range-beta -> handles range date selection logic
gux-date-picker-beta (uses gux-calendar-beta internally)
gux-date-picker-range-beta (uses gux-calendar-range-beta internally)
gux-calendar (unchanged from current implementation, stable)
gux-datepicker (unchanged from current implementation, stable)

We will reuse code between the single and range components above when applicable. I think it might be beneficial to build out the single and range calendar beta components first and then at that point see what makes sense for code reusability.

This PR came out of this one: https://github.com/MyPureCloud/genesys-webcomponents/pull/1307

I ended up creating a new branch off feature/V4 (COMUI-1595-v4) and ditching COMUI-1595 and COMUI-1595-v2. I was rebasing COMUI-1595-v3 on feature/V4, however, there were many commits to account for during this process and the rebase became messy, so I started from scratch by branching off feature/V4 again to create COMUI-1595-V4. 

I also closed the PR linked to COMUI-1595-v2 and COMUI-1595-v3 and opened this current one to link to COMUI-1595-v4.