### PR TITLE
fix(popup): fix floating ui implementation

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-dropdown-multi/gux-dropdown-multi.less
@@ -168,10 +168,6 @@
   color: @gux-black-50;
 }
 
-gux-popup-beta::part(gux-popup-container) {
-  width: inherit;
-}
-
 .gux-error-message-container {
   display: none;
   margin: 4px 0;

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
@@ -39,6 +39,9 @@ export class GuxPopupBeta {
   @Prop()
   disabled: boolean = false;
 
+  /**
+   * set if parent component design allows for popup exceeding target width
+   */
   @Prop()
   exceedTargetWidth: boolean = false;
 

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
@@ -5,8 +5,7 @@ import {
   Prop,
   Watch,
   Event,
-  EventEmitter,
-  Element
+  EventEmitter
 } from '@stencil/core';
 
 import {
@@ -34,14 +33,14 @@ export class GuxPopupBeta {
   private popupElementContainer: HTMLElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
 
-  @Element()
-  private root: HTMLGuxPopupElement;
-
   @Prop()
   expanded: boolean = false;
 
   @Prop()
   disabled: boolean = false;
+
+  @Prop()
+  exceedTargetWidth: boolean = false;
 
   /**
    * This event will run when the popup transitions to an expanded state.
@@ -72,9 +71,7 @@ export class GuxPopupBeta {
   private updatePosition(): void {
     if (this.targetElementContainer && this.popupElementContainer) {
       const popupElementContainer = this.popupElementContainer;
-      const componentTagName = (
-        (this.root as Element)?.getRootNode() as ShadowRoot
-      ).host.nodeName;
+      const assignMinWidth = this.exceedTargetWidth;
       void computePosition(
         this.targetElementContainer,
         this.popupElementContainer,
@@ -86,10 +83,7 @@ export class GuxPopupBeta {
             flip(),
             size({
               apply({ rects }: MiddlewareArguments) {
-                if (
-                  componentTagName == 'GUX-ACTION-BUTTON' ||
-                  componentTagName == 'GUX-BUTTON-MULTI'
-                ) {
+                if (assignMinWidth) {
                   Object.assign(popupElementContainer.style, {
                     minWidth: `${rects.reference.width}px`
                   });

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/gux-popup-beta.tsx
@@ -5,7 +5,8 @@ import {
   Prop,
   Watch,
   Event,
-  EventEmitter
+  EventEmitter,
+  Element
 } from '@stencil/core';
 
 import {
@@ -32,6 +33,9 @@ export class GuxPopupBeta {
   private targetElementContainer: HTMLElement;
   private popupElementContainer: HTMLElement;
   private cleanupUpdatePosition: ReturnType<typeof autoUpdate>;
+
+  @Element()
+  private root: HTMLGuxPopupElement;
 
   @Prop()
   expanded: boolean = false;
@@ -68,7 +72,9 @@ export class GuxPopupBeta {
   private updatePosition(): void {
     if (this.targetElementContainer && this.popupElementContainer) {
       const popupElementContainer = this.popupElementContainer;
-      const targetElementContainer = this.targetElementContainer;
+      const componentTagName = (
+        (this.root as Element)?.getRootNode() as ShadowRoot
+      ).host.nodeName;
       void computePosition(
         this.targetElementContainer,
         this.popupElementContainer,
@@ -80,12 +86,18 @@ export class GuxPopupBeta {
             flip(),
             size({
               apply({ rects }: MiddlewareArguments) {
-                Object.assign(popupElementContainer.style, {
-                  minWidth: `${rects.reference.width}px`
-                });
-                Object.assign(targetElementContainer.style, {
-                  width: `${rects.reference.width}px`
-                });
+                if (
+                  componentTagName == 'GUX-ACTION-BUTTON' ||
+                  componentTagName == 'GUX-BUTTON-MULTI'
+                ) {
+                  Object.assign(popupElementContainer.style, {
+                    minWidth: `${rects.reference.width}px`
+                  });
+                } else {
+                  Object.assign(popupElementContainer.style, {
+                    width: `${rects.reference.width}px`
+                  });
+                }
               }
             }),
             shift(),
@@ -146,7 +158,6 @@ export class GuxPopupBeta {
       >
         <slot name="target"></slot>
         <div
-          part="gux-popup-container"
           class={{
             'gux-popup-container': true,
             'gux-expanded': this.expanded && !this.disabled

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
@@ -29,13 +29,6 @@
 | `"target"` | Required slot for target |
 
 
-## Shadow Parts
-
-| Part                    | Description |
-| ----------------------- | ----------- |
-| `"gux-popup-container"` |             |
-
-
 ## Dependencies
 
 ### Used by

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property            | Attribute             | Description | Type      | Default |
-| ------------------- | --------------------- | ----------- | --------- | ------- |
-| `disabled`          | `disabled`            |             | `boolean` | `false` |
-| `exceedTargetWidth` | `exceed-target-width` |             | `boolean` | `false` |
-| `expanded`          | `expanded`            |             | `boolean` | `false` |
+| Property            | Attribute             | Description                                                            | Type      | Default |
+| ------------------- | --------------------- | ---------------------------------------------------------------------- | --------- | ------- |
+| `disabled`          | `disabled`            |                                                                        | `boolean` | `false` |
+| `exceedTargetWidth` | `exceed-target-width` | set if parent component design allows for popup exceeding target width | `boolean` | `false` |
+| `expanded`          | `expanded`            |                                                                        | `boolean` | `false` |
 
 
 ## Events

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type      | Default |
-| ---------- | ---------- | ----------- | --------- | ------- |
-| `disabled` | `disabled` |             | `boolean` | `false` |
-| `expanded` | `expanded` |             | `boolean` | `false` |
+| Property            | Attribute             | Description | Type      | Default |
+| ------------------- | --------------------- | ----------- | --------- | ------- |
+| `disabled`          | `disabled`            |             | `boolean` | `false` |
+| `exceedTargetWidth` | `exceed-target-width` |             | `boolean` | `false` |
+| `expanded`          | `expanded`            |             | `boolean` | `false` |
 
 
 ## Events

--- a/packages/genesys-spark-components/src/components/beta/gux-popup-beta/tests/__snapshots__/gux-popup-beta.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-popup-beta/tests/__snapshots__/gux-popup-beta.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`gux-popup-beta #render should render component as expected (1) 1`] = `
   <mock:shadow-root>
     <div class="gux-target-container">
       <slot name="target"></slot>
-      <div class="gux-popup-container" part="gux-popup-container">
+      <div class="gux-popup-container">
         <slot name="popup"></slot>
       </div>
     </div>
@@ -32,7 +32,7 @@ exports[`gux-popup-beta #render should render component as expected (2) 1`] = `
   <mock:shadow-root>
     <div class="gux-target-container">
       <slot name="target"></slot>
-      <div class="gux-expanded gux-popup-container" part="gux-popup-container">
+      <div class="gux-expanded gux-popup-container">
         <slot name="popup"></slot>
       </div>
     </div>
@@ -59,7 +59,7 @@ exports[`gux-popup-beta #render should render component as expected (3) 1`] = `
   <mock:shadow-root>
     <div class="gux-disabled gux-target-container">
       <slot name="target"></slot>
-      <div class="gux-popup-container" part="gux-popup-container">
+      <div class="gux-popup-container">
         <slot name="popup"></slot>
       </div>
     </div>
@@ -86,7 +86,7 @@ exports[`gux-popup-beta #render should render component as expected (4) 1`] = `
   <mock:shadow-root>
     <div class="gux-disabled gux-target-container">
       <slot name="target"></slot>
-      <div class="gux-popup-container" part="gux-popup-container">
+      <div class="gux-popup-container">
         <slot name="popup"></slot>
       </div>
     </div>

--- a/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-action-button/gux-action-button.tsx
@@ -190,7 +190,11 @@ export class GuxActionButton {
   render(): JSX.Element {
     return (
       <div class="gux-action-button-container">
-        <gux-popup-beta expanded={this.isOpen} disabled={this.disabled}>
+        <gux-popup-beta
+          expanded={this.isOpen}
+          disabled={this.disabled}
+          exceedTargetWidth
+        >
           <div slot="target" class="gux-action-button-container">
             <gux-button-slot-beta
               class="gux-action-button"

--- a/packages/genesys-spark-components/src/components/stable/gux-action-button/tests/__snapshots__/gux-action-button.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-action-button/tests/__snapshots__/gux-action-button.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`gux-action-button renders 1`] = `
 <gux-action-button accent="primary" lang="en" text="Primary">
   <mock:shadow-root>
     <div class="gux-action-button-container">
-      <gux-popup-beta>
+      <gux-popup-beta exceedtargetwidth="">
         <div class="gux-action-button-container" slot="target">
           <gux-button-slot-beta accent="primary" class="gux-action-button">
             <button type="button">

--- a/packages/genesys-spark-components/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-advanced-dropdown/gux-advanced-dropdown.less
@@ -114,7 +114,3 @@ gux-popup-beta {
     box-shadow: none;
   }
 }
-
-gux-popup-beta::part(gux-popup-container) {
-  width: inherit;
-}

--- a/packages/genesys-spark-components/src/components/stable/gux-button-multi/gux-button-multi.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-button-multi/gux-button-multi.tsx
@@ -167,7 +167,7 @@ export class GuxButtonMulti {
 
   render(): JSX.Element {
     return (
-      <gux-popup-beta expanded={this.isOpen}>
+      <gux-popup-beta expanded={this.isOpen} exceedTargetWidth>
         <div slot="target" class="gux-button-multi-container">
           <gux-button-slot-beta
             class="gux-dropdown-button"

--- a/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-dropdown/gux-dropdown.less
@@ -161,10 +161,6 @@
   color: @gux-black-50;
 }
 
-gux-popup-beta::part(gux-popup-container) {
-  width: inherit;
-}
-
 // Selected option styles
 
 .gux-selected-icon {

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox-multi/readme.md
@@ -7,6 +7,7 @@
 
 | Property        | Attribute         | Description | Type                                  | Default     |
 | --------------- | ----------------- | ----------- | ------------------------------------- | ----------- |
+| `emptyMessage`  | `empty-message`   |             | `string`                              | `undefined` |
 | `filter`        | `filter`          |             | `string`                              | `''`        |
 | `filterType`    | `filter-type`     |             | `"custom" \| "none" \| "starts-with"` | `'none'`    |
 | `hasExactMatch` | `has-exact-match` |             | `boolean`                             | `false`     |

--- a/packages/genesys-spark-components/src/components/stable/gux-listbox/readme.md
+++ b/packages/genesys-spark-components/src/components/stable/gux-listbox/readme.md
@@ -10,12 +10,13 @@ from a list of options.
 
 ## Properties
 
-| Property     | Attribute     | Description | Type                                  | Default     |
-| ------------ | ------------- | ----------- | ------------------------------------- | ----------- |
-| `filter`     | `filter`      |             | `string`                              | `''`        |
-| `filterType` | `filter-type` |             | `"custom" \| "none" \| "starts-with"` | `'none'`    |
-| `loading`    | `loading`     |             | `boolean`                             | `false`     |
-| `value`      | `value`       |             | `string`                              | `undefined` |
+| Property       | Attribute       | Description | Type                                  | Default     |
+| -------------- | --------------- | ----------- | ------------------------------------- | ----------- |
+| `emptyMessage` | `empty-message` |             | `string`                              | `undefined` |
+| `filter`       | `filter`        |             | `string`                              | `''`        |
+| `filterType`   | `filter-type`   |             | `"custom" \| "none" \| "starts-with"` | `'none'`    |
+| `loading`      | `loading`       |             | `boolean`                             | `false`     |
+| `value`        | `value`         |             | `string`                              | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
https://inindca.atlassian.net/browse/COMUI-2137


The issues we are currently seeing in the dropdown are linked to a new feature which was added to `gux-popup` which was to allow the lists of action and multi button to extend past its reference. To do this the `floating-ui` implementation was altered in order to achieve this. You can see the changes in this PR https://github.com/MyPureCloud/genesys-webcomponents/pull/1214/files

**Fix**
In this fix I am just verifying the components tag name. If the component is neither an action button nor a multi button then the default floating ui implementation will be used.

**Notes**
Seeing as the popup-beta component has to accommodate for multiple components which include dropdown / multi buttons etc if a request comes in to alter the floating ui implementation for a new feature it will cause an extra layer of complexity to preserve the existing functionality of the dropdowns or other components connected to the popup. My suggestion would be to have separate popups for components. Maybe there is a better way than this but what do people think about having a separate popup for the different components.