### PR TITLE
feat(footerslot): GAME-3835-footer-slot

### DIFF
--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/example.html
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/example.html
@@ -14,6 +14,11 @@
     max="2023-09"
   ></gux-month-picker-beta>
 
+  <h2>Footer Slot</h2>
+  <gux-month-picker-beta value="2022-01" min="2021-03" max="2023-09">
+    <div slot="footer">Footer Section Here</div>
+  </gux-month-picker-beta>
+
   <h2>Languages</h2>
   <div id="languages-container">
     <div id="sample"></div>

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.less
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.less
@@ -54,10 +54,13 @@
     }
   }
 
-  .gux-months {
+  .gux-months,
+  .gux-footer {
     padding: @gux-spacing-large;
     background-color: @gux-grey-100;
+  }
 
+  .gux-months {
     button {
       width: 65px;
       height: 50px;
@@ -86,5 +89,9 @@
         background-color: @gux-grey-100;
       }
     }
+  }
+
+  .gux-footer {
+    border-top: 1px solid @gux-grey-60;
   }
 }

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-calendar/gux-month-calendar.tsx
@@ -259,6 +259,17 @@ export class GuxMonthCalendar {
     ) as JSX.Element;
   }
 
+  private renderFooter(): JSX.Element {
+    const hasFooterSlot: boolean = !!this.root.querySelector('[slot="footer"]');
+    return hasFooterSlot
+      ? ((
+          <div class="gux-footer">
+            <slot name="footer"></slot>
+          </div>
+        ) as JSX.Element)
+      : (null as JSX.Element);
+  }
+
   private renderTrapFocusEl(): JSX.Element {
     return (
       <span onFocus={() => this.doFocusTrap()} tabindex="0"></span>
@@ -270,6 +281,7 @@ export class GuxMonthCalendar {
       <div class="gux-month-calendar">
         {this.renderHeader()}
         {this.renderMonths()}
+        {this.renderFooter()}
         {this.renderTrapFocusEl()}
       </div>
     ) as JSX.Element;

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.tsx
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/gux-month-picker.tsx
@@ -72,6 +72,9 @@ export class GuxMonthPicker {
   expanded: boolean = false;
 
   @State()
+  hasFooterSlot: boolean = false;
+
+  @State()
   locale: string;
 
   @Listen('keydown')
@@ -109,6 +112,7 @@ export class GuxMonthPicker {
     trackComponent(this.root);
     this.i18n = await buildI18nForComponent(this.root, translationResources);
     this.locale = getDesiredLocale(this.root);
+    this.hasFooterSlot = !!this.root.querySelector('[slot="footer"]');
   }
 
   private isOutOfBounds(value: GuxISOYearMonth): boolean {
@@ -364,8 +368,16 @@ export class GuxMonthPicker {
         value={this.value}
         min={this.min}
         max={this.max}
-      />
+      >
+        {this.renderFooter()}
+      </gux-month-calendar>
     ) as JSX.Element;
+  }
+
+  private renderFooter(): JSX.Element {
+    return this.hasFooterSlot
+      ? ((<slot slot="footer" name="footer" />) as JSX.Element)
+      : (null as JSX.Element);
   }
 
   render(): JSX.Element {

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/__snapshots__/gux-month-picker.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/__snapshots__/gux-month-picker.spec.ts.snap
@@ -165,3 +165,176 @@ exports[`gux-month-picker-beta #render should render the component as expected 1
   </mock:shadow-root>
 </gux-month-picker-beta>
 `;
+
+exports[`gux-month-picker-beta #render should render with footer the component as expected 1`] = `
+<gux-month-picker-beta value="2022-01">
+  <mock:shadow-root>
+    <gux-popup-beta>
+      <div class="gux-target" slot="target">
+        <span class="gux-display">
+          <div aria-label="Month" aria-valuemax="12" aria-valuemin="1" aria-valuenow="01" aria-valuetext="January 2022" class="gux-spinner" role="spinbutton" tabindex="0">
+            January
+          </div>
+          <div aria-label="Year" aria-valuemin="0" aria-valuenow="2022" aria-valuetext="January 2022" class="gux-spinner" role="spinbutton" tabindex="0">
+            2022
+          </div>
+        </span>
+        <button class="gux-popup-toggle" type="button">
+          <gux-icon icon-name="calendar" screenreader-text="Toggle month calendar view"></gux-icon>
+        </button>
+      </div>
+      <gux-month-calendar slot="popup">
+        <mock:shadow-root>
+          <div class="gux-month-calendar">
+            <div class="gux-year-header">
+              <button class="gux-year-change" type="button">
+                <gux-icon icon-name="chevron-small-left" screenreader-text="Current year is 2022, Click to change year to 2021"></gux-icon>
+              </button>
+              <div class="gux-year">
+                2022
+              </div>
+              <button class="gux-year-change" type="button">
+                <gux-icon icon-name="chevron-small-right" screenreader-text="Current year is 2022, Click to change year to 2023"></gux-icon>
+              </button>
+            </div>
+            <gux-month-list role="list" tabindex="1">
+              <mock:shadow-root>
+                <span tabindex="1"></span>
+                <slot></slot>
+              </mock:shadow-root>
+              <gux-month-list-item aria-label="January 2022" aria-selected="true" role="listitem" value="2022-01">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button class="gux-selected" tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Jan
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="February 2022" role="listitem" value="2022-02">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Feb
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="March 2022" role="listitem" value="2022-03">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Mar
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="April 2022" role="listitem" value="2022-04">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Apr
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="May 2022" role="listitem" value="2022-05">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                May
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="June 2022" role="listitem" value="2022-06">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Jun
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="July 2022" role="listitem" value="2022-07">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Jul
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="August 2022" role="listitem" value="2022-08">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Aug
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="September 2022" role="listitem" value="2022-09">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Sep
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="October 2022" role="listitem" value="2022-10">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Oct
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="November 2022" role="listitem" value="2022-11">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Nov
+              </gux-month-list-item>
+              <gux-month-list-item aria-label="December 2022" role="listitem" value="2022-12">
+                <mock:shadow-root>
+                  <div class="gux-container">
+                    <button tabindex="-1" type="button">
+                      <slot></slot>
+                    </button>
+                  </div>
+                </mock:shadow-root>
+                Dec
+              </gux-month-list-item>
+            </gux-month-list>
+            <div class="gux-footer">
+              <slot name="footer"></slot>
+            </div>
+            <span tabindex="0"></span>
+          </div>
+        </mock:shadow-root>
+        <slot name="footer" slot="footer"></slot>
+      </gux-month-calendar>
+    </gux-popup-beta>
+  </mock:shadow-root>
+  <div slot="footer">
+    Footer
+  </div>
+</gux-month-picker-beta>
+`;

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/gux-month-picker.e2e.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/gux-month-picker.e2e.ts
@@ -23,4 +23,17 @@ describe('gux-month-picker-beta', () => {
 
     expect(element.innerHTML).toMatchSnapshot();
   });
+
+  it('renders a footer section', async () => {
+    const page = await newSparkE2EPage({
+      html: `<gux-month-picker-beta>
+          <div slot="footer">Footer</div>
+        </gux-month-picker-beta>`
+    });
+    const monthpicker = await page.find('gux-month-picker-beta');
+    const element = await monthpicker.find('pierce/.gux-footer');
+
+    expect(element).toBeTruthy();
+    expect(element.innerHTML).toEqual(`<slot name="footer"></slot>`);
+  });
 });

--- a/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/gux-month-picker.spec.ts
+++ b/packages/genesys-spark-components/src/components/beta/gux-month-picker/tests/gux-month-picker.spec.ts
@@ -30,5 +30,13 @@ describe('gux-month-picker-beta', () => {
 
       expect(page.root).toMatchSnapshot();
     });
+
+    it(`should render with footer the component as expected`, async () => {
+      const html =
+        '<gux-month-picker-beta value=2022-01><div slot="footer">Footer</div></gux-month-picker-beta>';
+      const page = await newSpecPage({ components, language, html });
+
+      expect(page.root).toMatchSnapshot();
+    });
   });
 });

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/example.html
@@ -28,6 +28,21 @@
   </div>
 </div>
 
+<h2>Footer Slot</h2>
+<gux-calendar mode="single" value="1997-08-29" min-date="1997-08-25">
+  <div slot="footer">
+    <div id="footer-container">
+      <div class="gux-label">Time Zone</div>
+      <gux-time-zone-picker-beta
+        value="Etc/GMT+1"
+        workspace-default="America/Detroit"
+        ,
+        local-d
+      />
+    </div>
+  </div>
+</gux-calendar>
+
 <h2>Languages</h2>
 <div id="languages-container">
   <div id="sample"></div>
@@ -73,6 +88,12 @@
     gap: 10px;
     align-content: stretch;
     justify-content: flex-start;
+  }
+
+  #footer-container {
+    .gux-label {
+      margin-bottom: 5px;
+    }
   }
 
   .item {

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/example.html
@@ -30,17 +30,7 @@
 
 <h2>Footer Slot</h2>
 <gux-calendar mode="single" value="1997-08-29" min-date="1997-08-25">
-  <div slot="footer">
-    <div id="footer-container">
-      <div class="gux-label">Time Zone</div>
-      <gux-time-zone-picker-beta
-        value="Etc/GMT+1"
-        workspace-default="America/Detroit"
-        ,
-        local-d
-      />
-    </div>
-  </div>
+  <div slot="footer">Footer Section Here</div>
 </gux-calendar>
 
 <h2>Languages</h2>
@@ -88,12 +78,6 @@
     gap: 10px;
     align-content: stretch;
     justify-content: flex-start;
-  }
-
-  #footer-container {
-    .gux-label {
-      margin-bottom: 5px;
-    }
   }
 
   .item {

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
@@ -156,6 +156,11 @@
       }
     }
   }
+
+  .gux-footer {
+    padding: 20px;
+    border-top: 1px solid @gux-grey-60;
+  }
 }
 
 .gux-sr-only {

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.less
@@ -66,14 +66,18 @@
     }
   }
 
-  .gux-content {
-    display: flex;
-    align-items: flex-start;
+  .gux-content,
+  .gux-footer {
     padding: 20px 24px;
-    color: @gux-black-50;
     background-color: @gux-grey-100;
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
+  }
+
+  .gux-content {
+    display: flex;
+    align-items: flex-start;
+    color: @gux-black-50;
 
     table {
       width: 168px;
@@ -158,7 +162,6 @@
   }
 
   .gux-footer {
-    padding: 20px;
     border-top: 1px solid @gux-grey-60;
   }
 }

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.tsx
@@ -505,6 +505,16 @@ export class GuxCalendar {
     ) as JSX.Element;
   }
 
+  renderFooterSlot(): JSX.Element {
+    return this.hasFooterSlot
+      ? ((
+          <div class="gux-footer">
+            <slot name="footer"></slot>
+          </div>
+        ) as JSX.Element)
+      : (null as JSX.Element);
+  }
+
   render() {
     return (
       <div class="gux-calendar">
@@ -534,11 +544,7 @@ export class GuxCalendar {
             this.renderCalendarTable(index)
           )}
         </div>
-        {this.hasFooterSlot && (
-          <div class="gux-footer">
-            <slot name="footer"></slot>
-          </div>
-        )}
+        {this.renderFooterSlot()}
       </div>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-calendar/gux-calendar.tsx
@@ -89,6 +89,9 @@ export class GuxCalendar {
   @State()
   selectingDate: Date | null = null;
 
+  @State()
+  hasFooterSlot: boolean = false;
+
   /**
    * Triggered when user selects a date
    */
@@ -440,6 +443,8 @@ export class GuxCalendar {
       }
     }
     this.previewValue = fromIsoDate(this.value);
+
+    this.hasFooterSlot = !!this.root.querySelector('[slot="footer"]');
   }
 
   componentDidRender() {
@@ -529,6 +534,11 @@ export class GuxCalendar {
             this.renderCalendarTable(index)
           )}
         </div>
+        {this.hasFooterSlot && (
+          <div class="gux-footer">
+            <slot name="footer"></slot>
+          </div>
+        )}
       </div>
     ) as JSX.Element;
   }

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/example.html
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/example.html
@@ -63,6 +63,38 @@
 <h3>Sunday</h3>
 <gux-datepicker start-day-of-week="7"></gux-datepicker>
 
+<h2>Footer Slot</h2>
+
+<h3>Footer Empty</h3>
+<gux-datepicker
+  mode="range"
+  label-position="above"
+  value="2019-11-25/2019-12-02"
+  number-of-months="2"
+>
+  <div slot="footer">Footer Section Here</div>
+</gux-datepicker>
+
+<h3>Footer Time Zone</h3>
+<gux-datepicker
+  mode="range"
+  label-position="above"
+  value="2019-11-25/2019-12-02"
+  number-of-months="2"
+>
+  <div slot="footer">
+    <div id="footer-container">
+      <div class="gux-label">Time Zone</div>
+      <gux-time-zone-picker-beta
+        value="Etc/GMT+1"
+        workspace-default="America/Detroit"
+        ,
+        local-d
+      />
+    </div>
+  </div>
+</gux-datepicker>
+
 <h2>Languages</h2>
 <div id="languages-container"></div>
 
@@ -86,6 +118,12 @@
   });
 })()"
 >
+  #footer-container {
+    .gux-label {
+      margin-bottom: 5px;
+    }
+  }
+
   #languages-container {
     display: flex;
     flex-direction: column;

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/gux-datepicker.tsx
@@ -739,8 +739,17 @@ export class GuxDatepicker {
         maxDate={this.maxDate}
         numberOfMonths={this.numberOfMonths}
         startDayOfWeek={this.startDayOfWeek}
-      />
+      >
+        {this.renderFooterSlot()}
+      </gux-calendar>
     ) as JSX.Element;
+  }
+
+  renderFooterSlot(): JSX.Element {
+    const hasFooterSlot: boolean = !!this.root.querySelector('[slot="footer"]');
+    return hasFooterSlot
+      ? ((<slot slot="footer" name="footer" />) as JSX.Element)
+      : (null as JSX.Element);
   }
 
   renderStartDateField(): JSX.Element {

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/__snapshots__/gux-datepicker.spec.ts.snap
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/__snapshots__/gux-datepicker.spec.ts.snap
@@ -258,3 +258,31 @@ exports[`gux-datepicker #render should render component as expected (9) 1`] = `
   </mock:shadow-root>
 </gux-datepicker>
 `;
+
+exports[`gux-datepicker #render should render component as expected (10) 1`] = `
+<gux-datepicker start-day-of-week="6" value="1997-08-15">
+  <mock:shadow-root>
+    <div class="gux-datepicker">
+      <div class="gux-datepicker-field">
+        <label class="gux-datepicker-field-label gux-sr-only" htmlfor="gux-datepicker-i">
+          Date
+        </label>
+        <div class="gux-datepicker-field-input">
+          <div class="gux-datepicker-field-text-input">
+            <input id="gux-datepicker-i" type="text" value="08/15/1997">
+            <button aria-expanded="false" aria-label="Toggle calendar view" class="gux-calendar-toggle-button" type="button">
+              <gux-icon decorative="" icon-name="calendar"></gux-icon>
+            </button>
+          </div>
+          <gux-calendar maxdate="" mindate="" mode="single" numberofmonths="1" startdayofweek="6" tabindex="-1" value="1997-08-15">
+            <slot name="footer" slot="footer"></slot>
+          </gux-calendar>
+        </div>
+      </div>
+    </div>
+  </mock:shadow-root>
+  <div slot="footer">
+    Footer
+  </div>
+</gux-datepicker>
+`;

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/gux-datepicker.e2e.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/gux-datepicker.e2e.ts
@@ -21,6 +21,18 @@ describe('gux-datepicker', () => {
     expect(element).toHaveAttribute('hydrated');
   });
 
+  it('renders a footer section', async () => {
+    const page = await newSparkE2EPage({
+      html: `<gux-datepicker>
+          <div slot="footer">Footer</div>
+        </gux-datepicker>`
+    });
+    const datepicker = await page.find('gux-datepicker');
+    const element = await datepicker.find('pierce/.gux-footer');
+    expect(element).toBeTruthy();
+    expect(element.innerHTML).toEqual(`<slot name="footer"></slot>`);
+  });
+
   it('updates the text input state when the datepicker’s value property is set', async () => {
     const page = await newSparkE2EPage({
       html: `<gux-datepicker lang="en"></gux-datepicker>`

--- a/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/gux-datepicker.spec.ts
+++ b/packages/genesys-spark-components/src/components/stable/gux-datepicker/tests/gux-datepicker.spec.ts
@@ -25,7 +25,8 @@ describe('gux-datepicker', () => {
       `<gux-datepicker mode="range" value="2019-11-25/2019-12-02" min-date="2019-11-10" max-date="2019-12-31" number-of-months="2" ></gux-datepicker>`,
       `<gux-datepicker mode="range" value="2019-11-25/2019-12-02" min-date="2019-11-10" max-date="2019-12-31" number-of-months="2" format="mm.dd.yyyy" ></gux-datepicker>`,
       `<gux-datepicker mode="range" value="2019-11-25/2019-12-02" number-of-months="2" disabled></gux-datepicker>`,
-      `<gux-datepicker value="1997-08-15" start-day-of-week="6"></gux-datepicker>`
+      `<gux-datepicker value="1997-08-15" start-day-of-week="6"></gux-datepicker>`,
+      `<gux-datepicker value="1997-08-15" start-day-of-week="6"><div slot="footer">Footer</div></gux-datepicker>`
     ].forEach((input, index) => {
       it(`should render component as expected (${index + 1})`, async () => {
         const page = await newSpecPage({


### PR DESCRIPTION
This is a feature needed for https://inindca.atlassian.net/browse/PURE-2967 analytics timezone selection.

Common UI design has approved of the following design :


![Screen Shot 2023-08-30 at 3 21 33 PM](https://github.com/MyPureCloud/genesys-webcomponents/assets/143441520/4096162a-5e12-471b-8e05-062a58faa6fa)

In order to achieve this a footer slot has been added to the following components:

gux-datepicker
gux-calendar
gux-month-picker
gux-month-calendar

Story files for all components have been updated to show an example of the footer:

The datepicker has the most indepth example using the new timezone picker in the slot as an example

![Screen Shot 2023-08-30 at 3 25 16 PM](https://github.com/MyPureCloud/genesys-webcomponents/assets/143441520/6f798fb5-be2f-4a0a-9718-f2869e903768)

Tests updated for all components


